### PR TITLE
Added `GeometricMachineLearning` again to tests and imported `ZygotePullback` from there.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,13 +17,14 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 AbstractNeuralNetworks = "0.3, 0.4, 0.5, 0.6"
 Documenter = "1.8.0"
 ForwardDiff = "1"
+GeometricMachineLearning = "0.4.7"
 Latexify = "0.16"
 RuntimeGeneratedFunctions = "0.5"
 SymbolicUtils = "3, 4"
-Zygote = "0.6.73, 0.7"
-julia = "1.10"
 Symbolics = "7"
 Test = "1"
+Zygote = "0.6.73, 0.7"
+julia = "1.10"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -33,6 +34,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+GeometricMachineLearning = "194d25b2-d3f5-49f0-af24-c124f4aa80cc"
 
 [targets]
-test = ["Test", "ForwardDiff", "Random", "Documenter", "Latexify", "SafeTestsets", "Zygote"]
+test = ["Test", "ForwardDiff", "Random", "Documenter", "Latexify", "SafeTestsets", "Zygote", "GeometricMachineLearning"]

--- a/test/derivatives/pullback.jl
+++ b/test/derivatives/pullback.jl
@@ -3,20 +3,11 @@ using SymbolicNeuralNetworks: _get_params, _get_contents
 using AbstractNeuralNetworks
 using AbstractNeuralNetworks: params
 using Symbolics
-using AbstractNeuralNetworks: AbstractPullback, QPTOAT
+using GeometricMachineLearning: ZygotePullback
 import Zygote
 using Test
 import Random
 Random.seed!(123)
-
-####################################################################################################
-######################### this is copied from GeometricMachineLearning; will be again imported explicitly later.
-struct ZygotePullback{NNLT} <: AbstractPullback{NNLT}
-    loss::NNLT
-end
-(_pullback::ZygotePullback)(ps, model, input_nt::QPTOAT)::Tuple = Zygote.pullback(ps -> _pullback.loss(model, ps, input_nt), ps)
-(_pullback::ZygotePullback)(ps, model, input_nt_output_nt::Tuple{<:QPTOAT, <:QPTOAT})::Tuple = Zygote.pullback(ps -> _pullback.loss(model, ps, input_nt_output_nt...), ps)
-####################################################################################################
 
 compare_values(arr1::Array, arr2::Array) = @test arr1 ≈ arr2
 function compare_values(nt1::NamedTuple, nt2::NamedTuple)


### PR DESCRIPTION
This reverts the changes made in https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/pull/37/changes/f94a970f0b190e5d657418600f427a2350d0e199 (part of https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/pull/37) that were necessary to resolve a circular dependency issue.

>[!NOTE]
> Note that https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/commit/2dc6039caa171bff4501f56279536712e7e68961 reverts https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/pull/37/changes/f94a970f0b190e5d657418600f427a2350d0e199.