### PR TITLE
Generate code with CSE, in-place kernels and one function per equation set

### DIFF
--- a/scripts/codegen_comparison.jl
+++ b/scripts/codegen_comparison.jl
@@ -1,0 +1,102 @@
+# Reproduces the numbers that motivated the code-generation changes in `src/build_function/`.
+#
+# Three things are measured, for networks of increasing depth:
+#
+#   1. `Symbolics.build_function` with and without common subexpression elimination — time and
+#      size of the emitted code. Symbolics stores expressions as a hash-consed DAG but prints
+#      them as a tree, so without CSE every reuse of a subexpression is emitted again and the
+#      code grows exponentially with depth.
+#   2. `SymbolicPullback` construction, which is dominated by that code generation.
+#   3. Evaluating the pullback over a batch — time and allocations.
+#
+# Run with
+#     julia --project=. scripts/codegen_comparison.jl
+# Add `--all` to also generate the deep networks *without* CSE. Be warned: for 5-10-10-10-1 that
+# emits roughly 440 MB of code and takes minutes, which is exactly the point being made.
+
+using SymbolicNeuralNetworks
+using SymbolicNeuralNetworks: _reduce, symbolic_pullback, output_dimension
+using AbstractNeuralNetworks
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, FeedForwardLoss, params
+using Symbolics
+using Printf
+import Random
+
+Random.seed!(123)
+
+const RUN_EVERYTHING = "--all" ∈ ARGS
+const ARCHITECTURES = ((5, 10, 1), (5, 10, 10, 1), (5, 10, 10, 10, 1))
+# generating the pullback of a three-hidden-layer network without CSE is not practical
+const MAX_LAYERS_WITHOUT_CSE = 3
+const BATCH_SIZE = 100
+
+chain(dims) = Chain((Dense(dims[i], dims[i + 1], tanh) for i in 1:(length(dims) - 1))...)
+
+skip_without_cse(dims) = !RUN_EVERYTHING && length(dims) > MAX_LAYERS_WITHOUT_CSE
+
+"Time `Symbolics.build_function` and measure the size of the code it emits, per parameter block."
+function measure_codegen(dims, cse::Bool)
+    c = chain(dims)
+    snn = SymbolicNeuralNetwork(c)
+    @variables soutput[1:dims[end]]
+    blocks = symbolic_pullback(FeedForwardLoss()(c, params(snn), snn.input, soutput), snn)
+    args = (snn.input, soutput, values(params(snn))...)
+
+    seconds = 0.0
+    characters = 0
+    for block in blocks, layer in keys(block), array in keys(block[layer])
+        eq = Symbolics.scalarize(block[layer][array])
+        seconds += @elapsed code = _reduce(build_function(eq, args...; expression = Val{true}, cse = cse))
+        characters += length(string(code))
+    end
+    (; seconds, characters)
+end
+
+"Time `SymbolicPullback` end to end, then evaluate it over a batch."
+function measure_pullback(dims, cse::Bool)
+    c = chain(dims)
+    snn = SymbolicNeuralNetwork(c)
+    nn = NeuralNetwork(c)
+    ps = params(nn)
+
+    construction = @elapsed pb = SymbolicPullback(snn, FeedForwardLoss(); cse = cse)
+
+    input = rand(dims[1], BATCH_SIZE)
+    output = rand(dims[end], BATCH_SIZE)
+    evaluate() = pb(ps, c, (input, output))[2](1.0)
+    evaluate()  # compile the generated function before timing it
+    seconds = minimum(@elapsed(evaluate()) for _ in 1:10)
+    (; construction, seconds, bytes = @allocated evaluate())
+end
+
+println("Julia $(VERSION), $(BATCH_SIZE)-column batches\n")
+
+# compile `build_function` and the pullback machinery before anything is timed
+measure_codegen(ARCHITECTURES[1], true)
+measure_pullback(ARCHITECTURES[1], true)
+
+println("Code generation for the pullback, summed over all parameter blocks")
+@printf("%-20s %12s %12s %14s %14s %8s\n", "layers", "no cse (s)", "cse (s)", "no cse (chars)", "cse (chars)", "ratio")
+for dims in ARCHITECTURES
+    with = measure_codegen(dims, true)
+    if skip_without_cse(dims)
+        @printf("%-20s %12s %12.3f %14s %14d %8s\n", dims, "skipped", with.seconds, "skipped", with.characters, "-")
+    else
+        without = measure_codegen(dims, false)
+        @printf("%-20s %12.3f %12.3f %14d %14d %8.1f\n",
+            dims, without.seconds, with.seconds, without.characters, with.characters,
+            without.characters / with.characters)
+    end
+end
+
+println("\nSymbolicPullback: construction, then one batch")
+@printf("%-20s %12s %12s %12s\n", "layers", "build (s)", "eval (ms)", "alloc (KiB)")
+for dims in ARCHITECTURES
+    result = measure_pullback(dims, true)
+    @printf("%-20s %12.2f %12.3f %12.1f\n", dims, result.construction, result.seconds * 1e3, result.bytes / 1024)
+end
+
+if !RUN_EVERYTHING
+    println("\nRe-run with `--all` to include the deep networks without CSE (slow: ~440 MB of " *
+            "generated code for $(ARCHITECTURES[end])).")
+end

--- a/src/build_function/build_function.jl
+++ b/src/build_function/build_function.jl
@@ -9,23 +9,44 @@ This function can be called with:
 built_function(input, ps)
 ```
 
+# Keyword Arguments
+
+- `cse`: perform *common subexpression elimination* when generating code (default `true`). See [`_build_nn_function`](@ref).
+
 # Implementation
 
-Internally this is calling [`_build_nn_function`](@ref) and then *parallelizing* the expression via the index `k`.
+Internally this is calling [`_build_nn_function_iip`](@ref) and then *parallelizing* the expression via the index `k`.
+The kernel writes straight into a preallocated output array, so evaluating a batch costs a single allocation
+instead of one array per column plus a `Base.reduce` fold.
+
+For scalar-valued equations `Symbolics.build_function` does not emit an in-place form; those fall back to the
+out-of-place [`_build_nn_function`](@ref).
 
 # Extended Help
 
 The functions mentioned in the implementation section were adjusted ad-hoc to deal with problems that emerged on the fly.
 Other problems may occur. In case you bump into one please [open an issue on github](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues).
 """
-function build_nn_function(eq::EqT, nn::AbstractSymbolicNeuralNetwork)
-    build_nn_function(eq, params(nn), nn.input)
+function build_nn_function(eq::EqT, nn::AbstractSymbolicNeuralNetwork; cse::Bool = true)
+    build_nn_function(eq, params(nn), nn.input; cse = cse)
 end
 
 function build_nn_function(
-        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; reduce = hcat)
+        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
     @assert ( (reduce == hcat) || (reduce == +) ) "Keyword reduce either has to be + or hcat!"
-    gen_fun = _build_nn_function(eq, sparams, sinput)
+    sc_eq = Symbolics.scalarize(eq)
+    kernel! = _build_nn_function_iip(sc_eq, sparams, sinput; reduce = reduce, cse = cse)
+    isnothing(kernel!) && return _oop_batch_wrapper(_build_nn_function(sc_eq, sparams, sinput; cse = cse), reduce)
+    _iip_batch_wrapper(kernel!, size(sc_eq), reduce)
+end
+
+"""
+    _oop_batch_wrapper(gen_fun, reduce)
+
+Evaluate the out-of-place kernel `gen_fun` once per batch column and combine the results.
+Used for scalar-valued equations, for which there is no in-place kernel.
+"""
+function _oop_batch_wrapper(gen_fun, reduce)
     # Combine the per-column results in a single allocation. `mapreduce(…, hcat, …)` folds
     # `hcat` left-to-right, recopying the growing accumulator once per column (O(N²) in the
     # batch size); `Base.reduce(hcat, ::Vector)` sizes the result once instead (O(N)).
@@ -43,6 +64,80 @@ function build_nn_function(
     end
     gen_fun_returned
 end
+
+"""
+    _iip_batch_wrapper(kernel!, eq_size, reduce)
+
+Allocate the output once and let the in-place `kernel!` write every batch column into it.
+`eq_size` is the size of the (scalarized) equation, which fixes the shape of the result;
+see [`allocate_batch_output`](@ref).
+"""
+function _iip_batch_wrapper(kernel!, eq_size::Tuple, reduce)
+    function gen_fun_returned(x, ps)
+        out = allocate_batch_output(promoted_eltype(x, ps), eq_size, size(x, 2), reduce)
+        for k in axes(x, 2)
+            kernel!(out, x, ps, k)
+        end
+        out
+    end
+    function gen_fun_returned(x::Union{AbstractVector, Symbolics.Arr}, ps)
+        # for vectors we do not reshape the output, as it may be a matrix
+        out = allocate_single_output(promoted_eltype(x, ps), eq_size, reduce)
+        kernel!(out, reshape(x, length(x), 1), ps, 1)
+        out
+    end
+    # check this! (definitely not correct in all cases!)
+    function gen_fun_returned(x::AbstractArray{<:Number, 3}, ps)
+        output_not_reshaped = gen_fun_returned(
+            reshape(x, size(x, 1), size(x, 2) * size(x, 3)), ps)
+        reshape(output_not_reshaped, size(output_not_reshaped, 1), size(x, 2), size(x, 3))
+    end
+    gen_fun_returned
+end
+
+"""
+    promoted_eltype(args...)
+
+The element type the generated code will produce, promoted over all inputs.
+
+This is needed because the in-place kernels write into an array that we have to allocate
+*before* calling them, so the element type cannot be inferred from a result. Promoting over
+the inputs keeps `Float32` parameters, symbolic (`Num`) inputs and `ForwardDiff.Dual` numbers
+working.
+"""
+promoted_eltype(args...) = promote_type(map(_eltype, args)...)
+
+_eltype(x::AbstractArray) = eltype(x)
+_eltype(x::Number) = typeof(x)
+_eltype(x::Tuple) = promote_type(map(_eltype, x)...)
+_eltype(x::NamedTuple) = _eltype(values(x))
+_eltype(x::NeuralNetworkParameters) = _eltype(values(x))
+
+@doc raw"""
+    allocate_batch_output(T, eq_size, batch_size, reduce)
+
+Allocate the result of evaluating an equation of size `eq_size` over `batch_size` columns.
+
+The shape matches what `Base.reduce(reduce, ::Vector)` over the per-column results used to
+produce:
+- `reduce = +`: the per-column results are summed, so the result has the size of the equation.
+- `reduce = hcat`, vector-valued equation of length ``m``: an ``m\times{}N`` matrix.
+- `reduce = hcat`, equation of size ``(m, n, \ldots)``: the blocks are placed next to each
+  other, giving an ``m\times(n\cdot{}\ldots\cdot{}N)`` matrix.
+"""
+allocate_batch_output(::Type{T}, eq_size::Tuple, ::Integer, ::typeof(+)) where {T} = zeros(T, eq_size...)
+allocate_batch_output(::Type{T}, eq_size::Tuple{<:Integer}, batch_size::Integer, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size[1], batch_size)
+allocate_batch_output(::Type{T}, eq_size::Tuple, batch_size::Integer, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size[1], prod(Base.tail(eq_size)) * batch_size)
+
+"""
+    allocate_single_output(T, eq_size, reduce)
+
+Allocate the result of evaluating an equation of size `eq_size` for a single (vector) input.
+Unlike [`allocate_batch_output`](@ref) this keeps the shape of the equation, as the output may
+itself be a matrix.
+"""
+allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(+)) where {T} = zeros(T, eq_size...)
+allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size...)
 
 """
     _build_nn_function(eq, params, sinput)
@@ -72,6 +167,21 @@ built_function([1. 2.; 3. 4.], params(nn), 1)
 
 Note that we have to supply an extra argument (index) to `_build_nn_function` that we do not have to supply to [`build_nn_function`](@ref).
 
+# Keyword Arguments
+
+- `cse`: perform *common subexpression elimination* (default `true`).
+
+`Symbolics` stores an expression as a hash-consed *directed acyclic graph*, but
+`Symbolics.build_function` prints it as a *tree*. Every time a subexpression is reused — the
+output of layer ``n`` feeding each neuron of layer ``n+1``, or the forward pass shared by every
+block of a symbolic pullback — the whole subtree is emitted again, so both the size of the
+generated code and the amount of redundant arithmetic grow exponentially with the depth of the
+network. With `cse = true` the graph is emitted as a `let` block of intermediate bindings
+instead, which keeps code size proportional to the number of distinct nodes.
+
+Pass `cse = false` to recover the old (fully inlined) output; this is mostly useful for
+debugging, and for very small networks where the binding overhead is not amortized.
+
 # Implementation
 
 This first calls `Symbolics.build_function` with the keyword argument `expression = Val{true}` and then modifies the generated code by calling:
@@ -83,17 +193,86 @@ This first calls `Symbolics.build_function` with the keyword argument `expressio
 See the docstrings for those functions for details on how the code is modified.
 """
 function _build_nn_function(
-        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr)
+        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; cse::Bool = true)
     sc_eq = Symbolics.scalarize(eq)
-    code = build_function(sc_eq, sinput, values(sparams)...; expression = Val{true}) |>
-           _reduce
+    code = build_function_generated(_reduce, sc_eq, sinput, values(sparams)...; cse = cse)
     rewritten_code = fix_map_reduce(modify_input_arguments(rewrite_arguments(fix_create_array(code))))
     parallelized_code = make_kernel(rewritten_code)
     @RuntimeGeneratedFunction(parallelized_code)
 end
 
+"""
+    _reduce(a)
+
+Pick the *out-of-place* half of what `Symbolics.build_function` returns. It returns a
+`(out_of_place, in_place)` tuple for array-valued equations and a single expression for
+scalar-valued ones. See [`_reduce_iip`](@ref).
+"""
 _reduce(a) = a
 _reduce(a::Tuple) = a[1]
+
+"""
+    _reduce_iip(a)
+
+Pick the *in-place* half of what `Symbolics.build_function` returns, or `nothing` if there is
+none (which is the case for scalar-valued equations). See [`_reduce`](@ref).
+"""
+_reduce_iip(::Any) = nothing
+_reduce_iip(a::Tuple) = a[2]
+
+"""
+    build_function_generated(reducer, sc_eq, args...; cse)
+
+Call `Symbolics.build_function` and pick the relevant half of its output with `reducer`
+([`_reduce`](@ref) for the out-of-place form, [`_reduce_iip`](@ref) for the in-place one).
+
+!!! note "Unsupported: reductions over un-scalarized symbolic arrays"
+    Expressions containing an `arrayop` — a reduction over a `Symbolics.Arr` that has not been
+    scalarized, e.g. `sum(c(input, ps))` — generate code that refers to variables nothing binds,
+    so the resulting function throws an `UndefVarError` when it is called. This is independent
+    of `cse` (the two modes just mangle different names). Reduce over `collect(c(input, ps))`
+    instead.
+"""
+function build_function_generated(reducer, sc_eq, args...; cse::Bool)
+    reducer(build_function(sc_eq, args...; expression = Val{true}, cse = cse))
+end
+
+@doc raw"""
+    _build_nn_function_iip(eq, params, sinput; reduce, cse)
+
+Build an *in-place* kernel that writes the result for batch column `k` into a preallocated array:
+
+```julia
+kernel!(out, input, ps, k)
+```
+
+Returns `nothing` for scalar-valued equations, for which `Symbolics.build_function` emits no
+in-place form.
+
+# Implementation
+
+This works like [`_build_nn_function`](@ref), but keeps the second (in-place) half of what
+`Symbolics.build_function` returns and post-processes it with:
+1. [`fix_create_array`](@ref),
+2. [`rewrite_arguments`](@ref) — unchanged, because the `ˍ₋out` argument is not counted in the
+   `ˍ₋argN` numbering,
+3. [`modify_input_arguments_iip`](@ref),
+4. [`fix_map_reduce`](@ref),
+5. [`make_kernel_iip`](@ref).
+
+The in-place code addresses its output with a *linear* index (`ˍ₋out[i] = …`) whatever the shape
+of the equation, which is what lets [`make_kernel_iip`](@ref) offset the writes by the batch
+index instead of handing the kernel a view.
+"""
+function _build_nn_function_iip(
+        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
+    sc_eq = Symbolics.scalarize(eq)
+    code = build_function_generated(_reduce_iip, sc_eq, sinput, values(sparams)...; cse = cse)
+    isnothing(code) && return nothing
+    rewritten_code = fix_map_reduce(modify_input_arguments_iip(rewrite_arguments(fix_create_array(code))))
+    parallelized_code = make_kernel_iip(rewritten_code, reduce, length(sc_eq))
+    @RuntimeGeneratedFunction(parallelized_code)
+end
 
 """
     rewrite_arguments(s)
@@ -186,6 +365,36 @@ function modify_input_arguments(expression::Expr)
 end
 
 """
+    modify_input_arguments_iip(s)
+
+Change input arguments of type `(ˍ₋out, sinput, ps.L1, ps.L2)` etc to `(ˍ₋out, sinput, ps)`.
+
+This is the in-place counterpart of [`modify_input_arguments`](@ref) and should be used after
+[`rewrite_arguments`](@ref). See [`_build_nn_function_iip`](@ref).
+
+# Examples
+
+```jldoctest
+using SymbolicNeuralNetworks: modify_input_arguments_iip
+
+s = "(ˍ₋out, sinput, ps.L1, ps.L2, ps.L3)"
+modify_input_arguments_iip(s)
+
+# output
+"(ˍ₋out, sinput, ps)"
+```
+"""
+function modify_input_arguments_iip(s::AbstractString)
+    @assert contains(s, "(ˍ₋out, sinput, ") "The first input arguments must be ˍ₋out and sinput."
+    regex = r"\(ˍ₋out, sinput, ps[a-zA-Z0-9., ]+\)"
+    replace(s, regex => "(ˍ₋out, sinput, ps)")
+end
+
+function modify_input_arguments_iip(expression::Expr)
+    Meta.parse(modify_input_arguments_iip(string(expression)))
+end
+
+"""
    fix_create_array(s)
 
 Fix a problem that occurs in connection with `create_array`.
@@ -268,4 +477,68 @@ end
 
 function make_kernel(expression::Expr)
     Meta.parse(make_kernel(string(expression)))
+end
+
+@doc raw"""
+    make_kernel_iip(s, reduce, eq_length)
+
+The in-place counterpart of [`make_kernel`](@ref): add the batch index `k` to the arguments,
+index `sinput` with it, and redirect the writes to `ˍ₋out` so that a single preallocated array
+can hold the result for the whole batch.
+
+`eq_length` is the number of entries of the (scalarized) equation.
+
+Which redirection is applied depends on how the per-column results are combined:
+- `reduce = +`: the writes become `+=` and every column accumulates into the same buffer (which
+  [`allocate_batch_output`](@ref) zeroes).
+- `reduce = hcat`: the writes are shifted by ``(k - 1)\cdot\mathrm{eq\_length}``, which is exactly
+  the offset of block `k` in the column-major layout of the concatenated result.
+
+# Examples
+
+```jldoctest
+using SymbolicNeuralNetworks: make_kernel_iip
+
+s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2) \n end\n end"
+make_kernel_iip(s, hcat, 3)
+
+# output
+
+"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1 + (k - 1) * 3] = getindex(sinput, 2, k) \n end\n end"
+```
+
+```jldoctest
+using SymbolicNeuralNetworks: make_kernel_iip
+
+s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2) \n end\n end"
+make_kernel_iip(s, +, 3)
+
+# output
+
+"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 2, k) \n end\n end"
+```
+"""
+function make_kernel_iip(s::AbstractString, reduce, eq_length::Integer)
+    # add k to function arguments
+    s_added_k = replace(s, "function (ˍ₋out, sinput, ps)" => "function (ˍ₋out, sinput, ps, k)")
+    # add k in body of function
+    s_indexed = replace(s_added_k, r"getindex\(sinput, ([0-9]+)\)" => s"getindex(sinput, \1, k)")
+    redirect_output_writes(s_indexed, reduce, eq_length)
+end
+
+function make_kernel_iip(expression::Expr, reduce, eq_length::Integer)
+    Meta.parse(make_kernel_iip(string(expression), reduce, eq_length))
+end
+
+"""
+    redirect_output_writes(s, reduce, eq_length)
+
+Rewrite the `ˍ₋out[i] = …` assignments of in-place generated code. See [`make_kernel_iip`](@ref).
+"""
+function redirect_output_writes(s::AbstractString, ::typeof(+), ::Integer)
+    replace(s, r"ˍ₋out\[([0-9]+)\] = " => s"ˍ₋out[\1] += ")
+end
+
+function redirect_output_writes(s::AbstractString, ::typeof(hcat), eq_length::Integer)
+    replace(s, r"ˍ₋out\[([0-9]+)\] = " => SubstitutionString("ˍ₋out[\\1 + (k - 1) * $(eq_length)] = "))
 end

--- a/src/build_function/build_function.jl
+++ b/src/build_function/build_function.jl
@@ -12,6 +12,15 @@ built_function(input, ps)
 # Keyword Arguments
 
 - `cse`: perform *common subexpression elimination* when generating code (default `true`). See [`_build_nn_function`](@ref).
+- `inplace`: evaluate a batch with an in-place kernel (default `true`). See below.
+
+!!! warning "The default result cannot be differentiated with `Zygote`"
+    With `inplace = true` the returned function allocates its result and lets the generated kernel
+    *mutate* it, which `Zygote` does not support (`Mutating arrays is not supported`). Pass
+    `inplace = false` to get the out-of-place version, which evaluates the kernel once per batch
+    column and combines the results with `Base.reduce`; that one is differentiable, but allocates an
+    array per column. Forward-mode AD (`ForwardDiff`) works with either, as the element type of the
+    preallocated array is promoted over the inputs (see [`promoted_eltype`](@ref)).
 
 # Implementation
 
@@ -20,22 +29,25 @@ The kernel writes straight into a preallocated output array, so evaluating a bat
 instead of one array per column plus a `Base.reduce` fold.
 
 For scalar-valued equations `Symbolics.build_function` does not emit an in-place form; those fall back to the
-out-of-place [`_build_nn_function`](@ref).
+out-of-place [`_build_nn_function`](@ref), as does `inplace = false`.
 
 # Extended Help
 
 The functions mentioned in the implementation section were adjusted ad-hoc to deal with problems that emerged on the fly.
 Other problems may occur. In case you bump into one please [open an issue on github](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues).
 """
-function build_nn_function(eq::EqT, nn::AbstractSymbolicNeuralNetwork; cse::Bool = true)
-    build_nn_function(eq, params(nn), nn.input; cse = cse)
+function build_nn_function(eq::EqT, nn::AbstractSymbolicNeuralNetwork; cse::Bool = true, inplace::Bool = true)
+    build_nn_function(eq, params(nn), nn.input; cse = cse, inplace = inplace)
 end
 
 function build_nn_function(
-        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
+        eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr; reduce = hcat, cse::Bool = true, inplace::Bool = true)
     @assert ( (reduce == hcat) || (reduce == +) ) "Keyword reduce either has to be + or hcat!"
     sc_eq = Symbolics.scalarize(eq)
-    kernel! = _build_nn_function_iip(sc_eq, sparams, sinput; reduce = reduce, cse = cse)
+    # `Symbolics.build_function` emits no in-place form for a scalar equation, and generating the
+    # code only to throw it away is not free, so do not even ask for it in that case.
+    kernel! = (inplace && sc_eq isa AbstractArray) ?
+              _build_nn_function_iip(sc_eq, sparams, sinput; reduce = reduce, cse = cse) : nothing
     isnothing(kernel!) && return _oop_batch_wrapper(_build_nn_function(sc_eq, sparams, sinput; cse = cse), reduce)
     _iip_batch_wrapper(kernel!, size(sc_eq), reduce)
 end
@@ -104,6 +116,13 @@ This is needed because the in-place kernels write into an array that we have to 
 *before* calling them, so the element type cannot be inferred from a result. Promoting over
 the inputs keeps `Float32` parameters, symbolic (`Num`) inputs and `ForwardDiff.Dual` numbers
 working.
+
+Note that this derives the element type from the *inputs*, not from the expression, which the
+out-of-place path ([`_build_nn_function`](@ref)) does instead. The two can differ: an equation over
+integer inputs and integer parameters evaluates to a `Float64`, which no `Array{Int}` can hold. The
+allocators therefore widen an integer type with `float` (see [`allocate_batch_output`](@ref)). A
+`Float32` network whose generated code contains a `Float64` constant is rounded to `Float32` rather
+than widened, which is the behaviour one wants for the network but is worth being aware of.
 """
 promoted_eltype(args...) = promote_type(map(_eltype, args)...)
 
@@ -122,12 +141,19 @@ The shape matches what `Base.reduce(reduce, ::Vector)` over the per-column resul
 produce:
 - `reduce = +`: the per-column results are summed, so the result has the size of the equation.
 - `reduce = hcat`, vector-valued equation of length ``m``: an ``m\times{}N`` matrix.
-- `reduce = hcat`, equation of size ``(m, n, \ldots)``: the blocks are placed next to each
-  other, giving an ``m\times(n\cdot{}\ldots\cdot{}N)`` matrix.
+- `reduce = hcat`, matrix-valued equation of size ``(m, n)``: the blocks are placed next to each
+  other, giving an ``m\times(n\cdot{}N)`` matrix.
+
+Equations of rank three or higher are *not* covered by that correspondence — `hcat` concatenates
+those along their second dimension and keeps the third, whereas the linear indexing of the in-place
+kernel flattens everything past the first dimension. No such equation arises in this package.
+
+`T` is widened with `float` when it is an integer type: it comes from [`promoted_eltype`](@ref),
+i.e. from the inputs, and an equation over integer inputs generally does not evaluate to an integer.
 """
-allocate_batch_output(::Type{T}, eq_size::Tuple, ::Integer, ::typeof(+)) where {T} = zeros(T, eq_size...)
-allocate_batch_output(::Type{T}, eq_size::Tuple{<:Integer}, batch_size::Integer, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size[1], batch_size)
-allocate_batch_output(::Type{T}, eq_size::Tuple, batch_size::Integer, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size[1], prod(Base.tail(eq_size)) * batch_size)
+allocate_batch_output(::Type{T}, eq_size::Tuple, ::Integer, ::typeof(+)) where {T} = zeros(_float_if_integer(T), eq_size...)
+allocate_batch_output(::Type{T}, eq_size::Tuple{<:Integer}, batch_size::Integer, ::typeof(hcat)) where {T} = Array{_float_if_integer(T)}(undef, eq_size[1], batch_size)
+allocate_batch_output(::Type{T}, eq_size::Tuple, batch_size::Integer, ::typeof(hcat)) where {T} = Array{_float_if_integer(T)}(undef, eq_size[1], prod(Base.tail(eq_size)) * batch_size)
 
 """
     allocate_single_output(T, eq_size, reduce)
@@ -136,8 +162,17 @@ Allocate the result of evaluating an equation of size `eq_size` for a single (ve
 Unlike [`allocate_batch_output`](@ref) this keeps the shape of the equation, as the output may
 itself be a matrix.
 """
-allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(+)) where {T} = zeros(T, eq_size...)
-allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(hcat)) where {T} = Array{T}(undef, eq_size...)
+allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(+)) where {T} = zeros(_float_if_integer(T), eq_size...)
+allocate_single_output(::Type{T}, eq_size::Tuple, ::typeof(hcat)) where {T} = Array{_float_if_integer(T)}(undef, eq_size...)
+
+"""
+    _float_if_integer(T)
+
+`float(T)` for integer types, `T` for everything else. See [`allocate_batch_output`](@ref).
+`Bool` is included, as `float(Bool)` is `Float64`.
+"""
+_float_if_integer(::Type{T}) where {T <: Integer} = float(T)
+_float_if_integer(::Type{T}) where {T} = T
 
 """
     _build_nn_function(eq, params, sinput)
@@ -486,7 +521,8 @@ The in-place counterpart of [`make_kernel`](@ref): add the batch index `k` to th
 index `sinput` with it, and redirect the writes to `ˍ₋out` so that a single preallocated array
 can hold the result for the whole batch.
 
-`eq_length` is the number of entries of the (scalarized) equation.
+`eq_length` is the number of entries of the (scalarized) equation. The generated code assigns each
+of them exactly once, which [`redirect_output_writes`](@ref) checks.
 
 Which redirection is applied depends on how the per-column results are combined:
 - `reduce = +`: the writes become `+=` and every column accumulates into the same buffer (which
@@ -499,23 +535,23 @@ Which redirection is applied depends on how the per-column results are combined:
 ```jldoctest
 using SymbolicNeuralNetworks: make_kernel_iip
 
-s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2) \n end\n end"
-make_kernel_iip(s, hcat, 3)
+s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2)\n ˍ₋out[2] = getindex(sinput, 1) \n end\n end"
+make_kernel_iip(s, hcat, 2)
 
 # output
 
-"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1 + (k - 1) * 3] = getindex(sinput, 2, k) \n end\n end"
+"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1 + (k - 1) * 2] = getindex(sinput, 2, k)\n ˍ₋out[2 + (k - 1) * 2] = getindex(sinput, 1, k) \n end\n end"
 ```
 
 ```jldoctest
 using SymbolicNeuralNetworks: make_kernel_iip
 
-s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2) \n end\n end"
-make_kernel_iip(s, +, 3)
+s = "function (ˍ₋out, sinput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 2)\n ˍ₋out[2] = getindex(sinput, 1) \n end\n end"
+make_kernel_iip(s, +, 2)
 
 # output
 
-"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 2, k) \n end\n end"
+"function (ˍ₋out, sinput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 2, k)\n ˍ₋out[2] += getindex(sinput, 1, k) \n end\n end"
 ```
 """
 function make_kernel_iip(s::AbstractString, reduce, eq_length::Integer)
@@ -530,15 +566,30 @@ function make_kernel_iip(expression::Expr, reduce, eq_length::Integer)
     Meta.parse(make_kernel_iip(string(expression), reduce, eq_length))
 end
 
+const OUTPUT_WRITE_REGEX = r"ˍ₋out\[([0-9]+)\] = "
+
 """
     redirect_output_writes(s, reduce, eq_length)
 
 Rewrite the `ˍ₋out[i] = …` assignments of in-place generated code. See [`make_kernel_iip`](@ref).
+
+# Implementation
+
+Unlike the other rewrites in the pipeline this one cannot fail loudly on its own: a `replace` that
+matches nothing returns the string unchanged, and the kernel then still compiles and runs. It would
+just write every batch column into the same place (`reduce = hcat`) or overwrite instead of
+accumulate (`reduce = +`), i.e. silently return wrong numbers. We therefore check that there is
+exactly one assignment per entry of the equation, which is the property
+`test/build_function/codegen_drift.jl` guards upstream.
 """
-function redirect_output_writes(s::AbstractString, ::typeof(+), ::Integer)
-    replace(s, r"ˍ₋out\[([0-9]+)\] = " => s"ˍ₋out[\1] += ")
+function redirect_output_writes(s::AbstractString, reduce, eq_length::Integer)
+    n = length(collect(eachmatch(OUTPUT_WRITE_REGEX, s)))
+    @assert n == eq_length "Expected $(eq_length) `ˍ₋out[i] = …` assignments in the generated code, found $(n). `Symbolics.build_function` has most likely changed how it emits in-place code; see test/build_function/codegen_drift.jl."
+    _redirect_output_writes(s, reduce, eq_length)
 end
 
-function redirect_output_writes(s::AbstractString, ::typeof(hcat), eq_length::Integer)
-    replace(s, r"ˍ₋out\[([0-9]+)\] = " => SubstitutionString("ˍ₋out[\\1 + (k - 1) * $(eq_length)] = "))
+_redirect_output_writes(s::AbstractString, ::typeof(+), ::Integer) = replace(s, OUTPUT_WRITE_REGEX => s"ˍ₋out[\1] += ")
+
+function _redirect_output_writes(s::AbstractString, ::typeof(hcat), eq_length::Integer)
+    replace(s, OUTPUT_WRITE_REGEX => SubstitutionString("ˍ₋out[\\1 + (k - 1) * $(eq_length)] = "))
 end

--- a/src/build_function/build_function_arrays.jl
+++ b/src/build_function/build_function_arrays.jl
@@ -26,14 +26,21 @@ funcs_evaluated = funcs(input, params(nn))
  (c = [0.9576465981186686],)
 ```
 """
-function build_nn_function(eqs::AbstractArray{<:Union{NamedTuple, NeuralNetworkParameters}}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat)
-    ps_semi = [function_valued_parameters(eq, sparams, sinput...; reduce = reduce) for eq in eqs]
-    
-    _pbs_executable(ps_functions, params, input...) = apply_element_wise(ps_functions, params, input...)
-    __pbs_executable(input, params) = _pbs_executable(ps_semi, params, input)
-    __pbs_executable(input, output, params) = _pbs_executable(ps_semi, params, input, output)
-    __pbs_executable
+function build_nn_function(eqs::AbstractArray{<:Union{NamedTuple, NeuralNetworkParameters}}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+    # every element of `eqs` is generated jointly (see the `NamedTuple` method); the elements
+    # themselves are independent, so they stay separate functions
+    funcs = [build_nn_function(eq, sparams, sinput...; reduce = reduce, cse = cse) for eq in eqs]
+
+    _pbs_executable(input, params) = _collect_results(funcs, input, params)
+    _pbs_executable(input, output, params) = _collect_results(funcs, input, output, params)
+    _pbs_executable
 end
+
+# `symbolic_pullback` produces a zero-dimensional array when it differentiates a scalar loss.
+# As in `apply_element_wise`, that is turned into a one-element vector, which is the shape
+# `_get_contents` expects. Arrays of any other dimensionality keep their shape.
+_collect_results(funcs::AbstractArray{<:Any, 0}, args...) = [funcs[](args...)]
+_collect_results(funcs::AbstractArray, args...) = [f(args...) for f in funcs]
 
 """
     build_nn_function(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams, sinput...)
@@ -63,16 +70,133 @@ funcs_evaluated = funcs(input, params(nn))
 
 # Implementation
 
+All the entries of `eqs` are generated as a *single* function, whose flat output is split up
+again afterwards; see [`flatten_eqs`](@ref) and [`unflatten`](@ref). Generating one function per
+entry instead would re-derive everything the entries have in common — for a symbolic pullback
+that is the whole forward pass, once per parameter array — and would compile one
+`RuntimeGeneratedFunction` per entry rather than one in total.
+
+Equation sets that contain a scalar-valued entry fall back to one function per entry
+(via [`function_valued_parameters`](@ref) and [`apply_element_wise`](@ref)), because
+`Symbolics.build_function` emits no in-place form for scalars.
+"""
+function build_nn_function(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+    flattened = flatten_eqs(eqs)
+    isnothing(flattened) && return _build_nn_function_per_leaf(eqs, sparams, sinput...; reduce = reduce, cse = cse)
+    flat, template = flattened
+    joint = build_nn_function(flat, sparams, sinput...; reduce = reduce, cse = cse)
+    _joint_executable(input::AbstractArray, params::NeuralNetworkParameters) = unflatten(template, joint(input, params))
+    # return this one if sinput & soutput are supplied
+    __joint_executable(input::AbstractArray, output::AbstractArray, params::NeuralNetworkParameters) = unflatten(template, joint(input, output, params))
+    typeof(sinput) <: Tuple{<:Any, <:Any} ? __joint_executable : _joint_executable
+end
+
+"""
+    _build_nn_function_per_leaf(eqs, sparams, sinput...)
+
+Build one function per entry of `eqs`. This is the fallback for equation sets that the joint
+code path of [`build_nn_function(::Union{NamedTuple, NeuralNetworkParameters}, ::NeuralNetworkParameters, ::Symbolics.Arr...)`](@ref)
+cannot handle.
+
 Internally this is using [`function_valued_parameters`](@ref) and [`apply_element_wise`](@ref).
 """
-function build_nn_function(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat)
-    ps = function_valued_parameters(eqs, sparams, sinput...; reduce = reduce)
+function _build_nn_function_per_leaf(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+    ps = function_valued_parameters(eqs, sparams, sinput...; reduce = reduce, cse = cse)
     _pbs_executable(ps::Union{NamedTuple, NeuralNetworkParameters}, params::NeuralNetworkParameters, input::AbstractArray...) = apply_element_wise(ps, params, input...)
     __pbs_executable(input::AbstractArray, params::NeuralNetworkParameters) = _pbs_executable(ps, params, input)
     # return this one if sinput & soutput are supplied
     ___pbs_executable(input::AbstractArray, output::AbstractArray, params::NeuralNetworkParameters) = _pbs_executable(ps, params, input, output)
     typeof(sinput) <: Tuple{<:Any, <:Any} ? ___pbs_executable : __pbs_executable
 end
+
+@doc raw"""
+    FlatSlice(range, size)
+
+Where an entry of an equation set ended up in the flat vector that [`flatten_eqs`](@ref)
+produces, and which shape it has to be given again by [`unflatten`](@ref).
+"""
+struct FlatSlice{N}
+    range::UnitRange{Int}
+    size::NTuple{N, Int}
+end
+
+@doc raw"""
+    flatten_eqs(eqs)
+
+Concatenate every entry of `eqs` into one vector of scalar equations, together with a
+*template*: a copy of the nested structure of `eqs` in which each entry has been replaced by
+the [`FlatSlice`](@ref) describing where it went. [`unflatten`](@ref) reverses this.
+
+Returns `nothing` if any entry is scalar-valued, which the joint code path cannot handle.
+
+# Examples
+
+```jldoctest
+using SymbolicNeuralNetworks: flatten_eqs, SymbolicNeuralNetwork
+using AbstractNeuralNetworks: Chain, Dense, params
+
+c = Chain(Dense(2, 3, tanh))
+snn = SymbolicNeuralNetwork(c)
+flat, template = flatten_eqs((a = c(snn.input, params(snn)), b = c(snn.input, params(snn)).^2))
+(length(flat), template.a.range, template.b.range)
+
+# output
+
+(6, 1:3, 4:6)
+```
+"""
+function flatten_eqs(eqs::Union{NamedTuple, NeuralNetworkParameters})
+    flat = Num[]
+    template = _flatten_eqs!(flat, eqs)
+    isnothing(template) ? nothing : (flat, template)
+end
+
+_flatten_eqs!(flat::AbstractVector, eqs::NeuralNetworkParameters) = _flatten_children!(flat, eqs, NeuralNetworkParameters{keys(eqs)})
+_flatten_eqs!(flat::AbstractVector, eqs::NamedTuple) = _flatten_children!(flat, eqs, NamedTuple{keys(eqs)})
+
+function _flatten_children!(flat::AbstractVector, eqs, rewrap)
+    children = map(key -> _flatten_eqs!(flat, eqs[key]), keys(eqs))
+    any(isnothing, children) && return nothing
+    rewrap(children)
+end
+
+function _flatten_eqs!(flat::AbstractVector, eq)
+    scalarized = Symbolics.scalarize(eq)
+    # a scalar entry has no in-place kernel, so the whole set has to take the fallback path
+    scalarized isa AbstractArray || return nothing
+    offset = length(flat)
+    append!(flat, vec(collect(scalarized)))
+    FlatSlice((offset + 1):length(flat), size(scalarized))
+end
+
+@doc raw"""
+    unflatten(template, out)
+
+Split the flat result `out` of a jointly generated function back into the nested structure
+recorded in `template`. The inverse of [`flatten_eqs`](@ref).
+
+# Implementation
+
+Each entry is *copied* out of `out` rather than viewed into it, so that the entries are
+ordinary `Array`s (as they were when every entry had its own generated function) and cannot
+alias each other.
+
+`out` is indexed by its number of dimensions, which is how the layout of the batch is
+accounted for:
+- a vector when the per-column results were summed (`reduce = +`), in which case every entry
+  keeps the shape of its equation,
+- a ``P\times{}N`` matrix when they were concatenated (`reduce = hcat`), in which case an entry
+  of size ``(m, n, \ldots)`` becomes an ``m\times(n\cdot\ldots\cdot{}N)`` matrix, exactly as
+  `Base.reduce(hcat, …)` would have produced.
+"""
+unflatten(template::NeuralNetworkParameters, out::AbstractArray) = NeuralNetworkParameters{keys(template)}(map(t -> unflatten(t, out), values(template)))
+unflatten(template::NamedTuple, out::AbstractArray) = NamedTuple{keys(template)}(map(t -> unflatten(t, out), values(template)))
+
+unflatten(slice::FlatSlice, out::AbstractVector) = reshape(out[slice.range], slice.size...)
+function unflatten(slice::FlatSlice, out::AbstractMatrix)
+    reshape(out[slice.range, :], slice.size[1], prod(Base.tail(slice.size)) * size(out, 2))
+end
+unflatten(slice::FlatSlice, out::AbstractArray{<:Any, 3}) = out[slice.range, :, :]
 
 """
     function_valued_parameters(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams, sinput...)
@@ -104,13 +228,13 @@ b = c(input, ps).^2
 (true, true)
 ```
 """
-function function_valued_parameters(eqs::NeuralNetworkParameters, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat)
-    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce) for key in keys(eqs))
+function function_valued_parameters(eqs::NeuralNetworkParameters, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse) for key in keys(eqs))
     NeuralNetworkParameters{keys(eqs)}(vals)
 end
 
-function function_valued_parameters(eqs::NamedTuple, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat)
-    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce) for key in keys(eqs))
+function function_valued_parameters(eqs::NamedTuple, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse) for key in keys(eqs))
     NamedTuple{keys(eqs)}(vals)
 end
 

--- a/src/build_function/build_function_arrays.jl
+++ b/src/build_function/build_function_arrays.jl
@@ -26,10 +26,10 @@ funcs_evaluated = funcs(input, params(nn))
  (c = [0.9576465981186686],)
 ```
 """
-function build_nn_function(eqs::AbstractArray{<:Union{NamedTuple, NeuralNetworkParameters}}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+function build_nn_function(eqs::AbstractArray{<:Union{NamedTuple, NeuralNetworkParameters}}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true, inplace::Bool = true)
     # every element of `eqs` is generated jointly (see the `NamedTuple` method); the elements
     # themselves are independent, so they stay separate functions
-    funcs = [build_nn_function(eq, sparams, sinput...; reduce = reduce, cse = cse) for eq in eqs]
+    funcs = [build_nn_function(eq, sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace) for eq in eqs]
 
     _pbs_executable(input, params) = _collect_results(funcs, input, params)
     _pbs_executable(input, output, params) = _collect_results(funcs, input, output, params)
@@ -79,12 +79,16 @@ that is the whole forward pass, once per parameter array — and would compile o
 Equation sets that contain a scalar-valued entry fall back to one function per entry
 (via [`function_valued_parameters`](@ref) and [`apply_element_wise`](@ref)), because
 `Symbolics.build_function` emits no in-place form for scalars.
+
+Joint code generation is independent of the `inplace` keyword: `inplace = false` still generates the
+whole set as one function, it just evaluates it out of place (and is then `Zygote`-differentiable;
+see [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)`](@ref)).
 """
-function build_nn_function(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
+function build_nn_function(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true, inplace::Bool = true)
     flattened = flatten_eqs(eqs)
-    isnothing(flattened) && return _build_nn_function_per_leaf(eqs, sparams, sinput...; reduce = reduce, cse = cse)
+    isnothing(flattened) && return _build_nn_function_per_leaf(eqs, sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace)
     flat, template = flattened
-    joint = build_nn_function(flat, sparams, sinput...; reduce = reduce, cse = cse)
+    joint = build_nn_function(flat, sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace)
     _joint_executable(input::AbstractArray, params::NeuralNetworkParameters) = unflatten(template, joint(input, params))
     # return this one if sinput & soutput are supplied
     __joint_executable(input::AbstractArray, output::AbstractArray, params::NeuralNetworkParameters) = unflatten(template, joint(input, output, params))
@@ -100,8 +104,8 @@ cannot handle.
 
 Internally this is using [`function_valued_parameters`](@ref) and [`apply_element_wise`](@ref).
 """
-function _build_nn_function_per_leaf(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
-    ps = function_valued_parameters(eqs, sparams, sinput...; reduce = reduce, cse = cse)
+function _build_nn_function_per_leaf(eqs::Union{NamedTuple, NeuralNetworkParameters}, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true, inplace::Bool = true)
+    ps = function_valued_parameters(eqs, sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace)
     _pbs_executable(ps::Union{NamedTuple, NeuralNetworkParameters}, params::NeuralNetworkParameters, input::AbstractArray...) = apply_element_wise(ps, params, input...)
     __pbs_executable(input::AbstractArray, params::NeuralNetworkParameters) = _pbs_executable(ps, params, input)
     # return this one if sinput & soutput are supplied
@@ -228,13 +232,13 @@ b = c(input, ps).^2
 (true, true)
 ```
 """
-function function_valued_parameters(eqs::NeuralNetworkParameters, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
-    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse) for key in keys(eqs))
+function function_valued_parameters(eqs::NeuralNetworkParameters, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true, inplace::Bool = true)
+    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace) for key in keys(eqs))
     NeuralNetworkParameters{keys(eqs)}(vals)
 end
 
-function function_valued_parameters(eqs::NamedTuple, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true)
-    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse) for key in keys(eqs))
+function function_valued_parameters(eqs::NamedTuple, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr...; reduce = hcat, cse::Bool = true, inplace::Bool = true)
+    vals = Tuple(build_nn_function(eqs[key], sparams, sinput...; reduce = reduce, cse = cse, inplace = inplace) for key in keys(eqs))
     NamedTuple{keys(eqs)}(vals)
 end
 

--- a/src/build_function/build_function_double_input.jl
+++ b/src/build_function/build_function_double_input.jl
@@ -8,18 +8,27 @@ built_function(input, output, ps)
 
 Also compare this to [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)`](@ref).
 
+# Keyword Arguments
+
+- `cse`: perform *common subexpression elimination* when generating code (default `true`).
+- `inplace`: evaluate a batch with an in-place kernel (default `true`). As for the single-input case
+  the default result mutates a preallocated array and can therefore not be differentiated with
+  `Zygote`; see [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)`](@ref).
+
 # Extended Help
 
 See the *extended help section* of [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)`](@ref).
 """
-function build_nn_function(eqs, nn::AbstractSymbolicNeuralNetwork, soutput; cse::Bool = true)
-    build_nn_function(eqs, params(nn), nn.input, soutput; cse = cse)
+function build_nn_function(eqs, nn::AbstractSymbolicNeuralNetwork, soutput; cse::Bool = true, inplace::Bool = true)
+    build_nn_function(eqs, params(nn), nn.input, soutput; cse = cse, inplace = inplace)
 end
 
-function build_nn_function(eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
+function build_nn_function(eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; reduce = hcat, cse::Bool = true, inplace::Bool = true)
     @assert ( (reduce == hcat) || (reduce == +) ) "Keyword reduce either has to be + or hcat!"
     sc_eq = Symbolics.scalarize(eq)
-    kernel! = _build_nn_function_iip(sc_eq, sparams, sinput, soutput; reduce = reduce, cse = cse)
+    # see the single-input method on why scalar equations skip the in-place attempt entirely
+    kernel! = (inplace && sc_eq isa AbstractArray) ?
+              _build_nn_function_iip(sc_eq, sparams, sinput, soutput; reduce = reduce, cse = cse) : nothing
     isnothing(kernel!) && return _oop_batch_wrapper2(_build_nn_function(sc_eq, sparams, sinput, soutput; cse = cse), reduce)
     _iip_batch_wrapper2(kernel!, size(sc_eq), reduce)
 end
@@ -222,12 +231,12 @@ The two-input counterpart of [`make_kernel_iip`](@ref).
 ```jldoctest
 using SymbolicNeuralNetworks: make_kernel_iip2
 
-s = "function (ˍ₋out, sinput, soutput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 1) + getindex(soutput, 2) \n end\n end"
+s = "function (ˍ₋out, sinput, soutput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 1) + getindex(soutput, 2)\n ˍ₋out[2] = getindex(sinput, 2) \n end\n end"
 make_kernel_iip2(s, +, 2)
 
 # output
 
-"function (ˍ₋out, sinput, soutput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 1, k) + getindex(soutput, 2, k) \n end\n end"
+"function (ˍ₋out, sinput, soutput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 1, k) + getindex(soutput, 2, k)\n ˍ₋out[2] += getindex(sinput, 2, k) \n end\n end"
 ```
 """
 function make_kernel_iip2(s::AbstractString, reduce, eq_length::Integer)

--- a/src/build_function/build_function_double_input.jl
+++ b/src/build_function/build_function_double_input.jl
@@ -12,13 +12,24 @@ Also compare this to [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)
 
 See the *extended help section* of [`build_nn_function(::EqT, ::AbstractSymbolicNeuralNetwork)`](@ref).
 """
-function build_nn_function(eqs, nn::AbstractSymbolicNeuralNetwork, soutput)
-    build_nn_function(eqs, params(nn), nn.input, soutput)
+function build_nn_function(eqs, nn::AbstractSymbolicNeuralNetwork, soutput; cse::Bool = true)
+    build_nn_function(eqs, params(nn), nn.input, soutput; cse = cse)
 end
 
-function build_nn_function(eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; reduce = hcat)
+function build_nn_function(eq::EqT, sparams::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
     @assert ( (reduce == hcat) || (reduce == +) ) "Keyword reduce either has to be + or hcat!"
-    gen_fun = _build_nn_function(eq, sparams, sinput, soutput)
+    sc_eq = Symbolics.scalarize(eq)
+    kernel! = _build_nn_function_iip(sc_eq, sparams, sinput, soutput; reduce = reduce, cse = cse)
+    isnothing(kernel!) && return _oop_batch_wrapper2(_build_nn_function(sc_eq, sparams, sinput, soutput; cse = cse), reduce)
+    _iip_batch_wrapper2(kernel!, size(sc_eq), reduce)
+end
+
+"""
+    _oop_batch_wrapper2(gen_fun, reduce)
+
+The two-input counterpart of [`_oop_batch_wrapper`](@ref).
+"""
+function _oop_batch_wrapper2(gen_fun, reduce)
     # Single-allocation combine over the batch dimension; see the note in `build_function.jl`
     # on why `mapreduce(…, hcat, …)` is O(N²) and `Base.reduce(hcat, ::Vector)` is O(N).
     gen_fun_returned(input, output, ps) = Base.reduce(reduce, [gen_fun(input, output, ps, k) for k in axes(input, 2)])
@@ -28,7 +39,34 @@ function build_nn_function(eq::EqT, sparams::NeuralNetworkParameters, sinput::Sy
         output_not_reshaped
     end
     # check this! (definitely not correct in all cases!)
-    function gen_fun_returned(x::AT, y::AT, ps) where {AT <: AbstractArray{<:Number, 3}} 
+    function gen_fun_returned(x::AT, y::AT, ps) where {AT <: AbstractArray{<:Number, 3}}
+        output_not_reshaped = gen_fun_returned(reshape(x, size(x, 1), size(x, 2) * size(x, 3)), reshape(y, size(y, 1), size(y, 2) * size(y, 3)), ps)
+        # if arrays are added together then don't reshape!
+        optional_reshape(output_not_reshaped, reduce, x)
+    end
+    gen_fun_returned
+end
+
+"""
+    _iip_batch_wrapper2(kernel!, eq_size, reduce)
+
+The two-input counterpart of [`_iip_batch_wrapper`](@ref).
+"""
+function _iip_batch_wrapper2(kernel!, eq_size::Tuple, reduce)
+    function gen_fun_returned(input, output, ps)
+        out = allocate_batch_output(promoted_eltype(input, output, ps), eq_size, size(input, 2), reduce)
+        for k in axes(input, 2)
+            kernel!(out, input, output, ps, k)
+        end
+        out
+    end
+    function gen_fun_returned(x::AT, y::AT, ps) where {AT <: Union{AbstractVector, Symbolics.Arr}}
+        output_not_reshaped = gen_fun_returned(reshape(x, length(x), 1), reshape(y, length(y), 1), ps)
+        # for vectors we do not reshape, as the output may be a matrix
+        output_not_reshaped
+    end
+    # check this! (definitely not correct in all cases!)
+    function gen_fun_returned(x::AT, y::AT, ps) where {AT <: AbstractArray{<:Number, 3}}
         output_not_reshaped = gen_fun_returned(reshape(x, size(x, 1), size(x, 2) * size(x, 3)), reshape(y, size(y, 1), size(y, 2) * size(y, 3)), ps)
         # if arrays are added together then don't reshape!
         optional_reshape(output_not_reshaped, reduce, x)
@@ -50,6 +88,10 @@ end
 Build a function that can process a matrix.
 See [`build_nn_function(::EqT, ::NeuralNetworkParameters, ::Symbolics.Arr)`](@ref).
 
+# Keyword Arguments
+
+- `cse`: perform *common subexpression elimination* (default `true`). See [`_build_nn_function(::EqT, ::NeuralNetworkParameters, ::Symbolics.Arr)`](@ref).
+
 # Implementation
 
 Note that we have two input arguments here which means this method processes code differently than [`_build_nn_function(::EqT, ::NeuralNetworkParameters, ::Symbolics.Arr, ::Symbolics.Arr)`](@ref). Here we call:
@@ -58,13 +100,34 @@ Note that we have two input arguments here which means this method processes cod
 3. [`modify_input_arguments2`](@ref),
 4. [`fix_map_reduce`](@ref).
 
-See the docstrings for those functions for details on how the code is modified. 
+See the docstrings for those functions for details on how the code is modified.
 """
-function _build_nn_function(eq::EqT, params::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr)
+function _build_nn_function(eq::EqT, params::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; cse::Bool = true)
     sc_eq = Symbolics.scalarize(eq)
-    code = build_function(sc_eq, sinput, soutput, values(params)...; expression = Val{true}) |> _reduce
+    code = build_function_generated(_reduce, sc_eq, sinput, soutput, values(params)...; cse = cse)
     rewritten_code = fix_map_reduce(modify_input_arguments2(rewrite_arguments2(fix_create_array(code))))
     parallelized_code = make_kernel2(rewritten_code)
+    @RuntimeGeneratedFunction(parallelized_code)
+end
+
+"""
+    _build_nn_function_iip(eq, params, sinput, soutput; reduce, cse)
+
+The two-input counterpart of [`_build_nn_function_iip(::EqT, ::NeuralNetworkParameters, ::Symbolics.Arr)`](@ref).
+The resulting kernel is called with `kernel!(out, input, output, ps, k)`.
+
+# Implementation
+
+As for the single-input case, [`rewrite_arguments2`](@ref) can be reused unchanged: the `ˍ₋out`
+argument that `Symbolics.build_function` prepends to the in-place signature is not counted in
+the `ˍ₋argN` numbering.
+"""
+function _build_nn_function_iip(eq::EqT, params::NeuralNetworkParameters, sinput::Symbolics.Arr, soutput::Symbolics.Arr; reduce = hcat, cse::Bool = true)
+    sc_eq = Symbolics.scalarize(eq)
+    code = build_function_generated(_reduce_iip, sc_eq, sinput, soutput, values(params)...; cse = cse)
+    isnothing(code) && return nothing
+    rewritten_code = fix_map_reduce(modify_input_arguments_iip2(rewrite_arguments2(fix_create_array(code))))
+    parallelized_code = make_kernel_iip2(rewritten_code, reduce, length(sc_eq))
     @RuntimeGeneratedFunction(parallelized_code)
 end
 
@@ -96,6 +159,34 @@ function modify_input_arguments2(expression::Expr)
     Meta.parse(modify_input_arguments2(string(expression)))
 end
 
+"""
+    modify_input_arguments_iip2(s)
+
+Change input arguments of type `(ˍ₋out, sinput, soutput, ps.L1, ps.L2)` etc to
+`(ˍ₋out, sinput, soutput, ps)`. See [`modify_input_arguments_iip`](@ref).
+
+# Examples
+
+```jldoctest
+using SymbolicNeuralNetworks: modify_input_arguments_iip2
+
+s = "(ˍ₋out, sinput, soutput, ps.L1, ps.L2, ps.L3)"
+modify_input_arguments_iip2(s)
+
+# output
+"(ˍ₋out, sinput, soutput, ps)"
+```
+"""
+function modify_input_arguments_iip2(s::AbstractString)
+    @assert contains(s, "(ˍ₋out, sinput, soutput, ") "The first input arguments must be ˍ₋out, sinput and soutput."
+    regex = r"\(ˍ₋out, sinput, soutput, ps[a-zA-Z0-9., ]+\)"
+    replace(s, regex => "(ˍ₋out, sinput, soutput, ps)")
+end
+
+function modify_input_arguments_iip2(expression::Expr)
+    Meta.parse(modify_input_arguments_iip2(string(expression)))
+end
+
 @doc raw"""
 # Examples
 ```jldoctest
@@ -119,6 +210,37 @@ end
 
 function make_kernel2(expression::Expr)
     Meta.parse(make_kernel2(string(expression)))
+end
+
+@doc raw"""
+    make_kernel_iip2(s, reduce, eq_length)
+
+The two-input counterpart of [`make_kernel_iip`](@ref).
+
+# Examples
+
+```jldoctest
+using SymbolicNeuralNetworks: make_kernel_iip2
+
+s = "function (ˍ₋out, sinput, soutput, ps)\n begin\n ˍ₋out[1] = getindex(sinput, 1) + getindex(soutput, 2) \n end\n end"
+make_kernel_iip2(s, +, 2)
+
+# output
+
+"function (ˍ₋out, sinput, soutput, ps, k)\n begin\n ˍ₋out[1] += getindex(sinput, 1, k) + getindex(soutput, 2, k) \n end\n end"
+```
+"""
+function make_kernel_iip2(s::AbstractString, reduce, eq_length::Integer)
+    # add k to function arguments
+    s_added_k = replace(s, "function (ˍ₋out, sinput, soutput, ps)" => "function (ˍ₋out, sinput, soutput, ps, k)")
+    # add k in body of function
+    s_added_k_input = replace(s_added_k, r"getindex\(sinput, ([0-9]+)\)" => s"getindex(sinput, \1, k)")
+    s_indexed = replace(s_added_k_input, r"getindex\(soutput, ([0-9]+)\)" => s"getindex(soutput, \1, k)")
+    redirect_output_writes(s_indexed, reduce, eq_length)
+end
+
+function make_kernel_iip2(expression::Expr, reduce, eq_length::Integer)
+    Meta.parse(make_kernel_iip2(string(expression), reduce, eq_length))
 end
 
 """

--- a/src/derivatives/pullback.jl
+++ b/src/derivatives/pullback.jl
@@ -25,6 +25,10 @@ typeof(pb(ps, nn.model, (rand(2), rand(1)))[2](1))
 @NamedTuple{L1::@NamedTuple{W::Matrix{Float64}, b::Vector{Float64}}}
 ```
 
+# Keyword Arguments
+
+- `cse`: perform *common subexpression elimination* when generating code (default `true`). This matters a lot here: without it every one of the `2 * n_layers` generated blocks re-emits the entire forward pass, which makes the code for networks with more than one hidden layer intractably large. See [`_build_nn_function`](@ref).
+
 # Implementation
 
 An instance of `SymbolicPullback` stores
@@ -88,11 +92,11 @@ struct SymbolicPullback{NNLT, FT} <: AbstractPullback{NNLT}
     fun::FT
 end
 
-function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss)
+function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss; cse::Bool = true)
     @variables soutput[1:output_dimension(nn.model)]
     symbolic_loss = loss(nn.model, params(nn), nn.input, soutput)
     symbolic_pullbacks = symbolic_pullback(symbolic_loss, nn)
-    pbs_executable = build_nn_function(symbolic_pullbacks, params(nn), nn.input, soutput; reduce = +)
+    pbs_executable = build_nn_function(symbolic_pullbacks, params(nn), nn.input, soutput; reduce = +, cse = cse)
     function pbs(input, output, params)
         pullback(::Union{Real, AbstractArray{<:Real}}) = _get_contents(_get_params(pbs_executable(input, output, params)))
         pullback
@@ -100,7 +104,7 @@ function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss)
     SymbolicPullback(loss, pbs)
 end
 
-SymbolicPullback(nn::SymbolicNeuralNetwork) = SymbolicPullback(nn, AbstractNeuralNetworks.FeedForwardLoss())
+SymbolicPullback(nn::SymbolicNeuralNetwork; cse::Bool = true) = SymbolicPullback(nn, AbstractNeuralNetworks.FeedForwardLoss(); cse = cse)
 
 """
     _get_params(ps::NeuralNetworkParameters)

--- a/src/derivatives/pullback.jl
+++ b/src/derivatives/pullback.jl
@@ -28,6 +28,7 @@ typeof(pb(ps, nn.model, (rand(2), rand(1)))[2](1))
 # Keyword Arguments
 
 - `cse`: perform *common subexpression elimination* when generating code (default `true`). This matters a lot here: without it every one of the `2 * n_layers` generated blocks re-emits the entire forward pass, which makes the code for networks with more than one hidden layer intractably large. See [`_build_nn_function`](@ref).
+- `inplace`: evaluate a batch with an in-place kernel (default `true`). The pullback is the end of the differentiation chain, so nothing differentiates through it and the default is what you want here; `inplace = false` exists for symmetry with [`build_nn_function`](@ref).
 
 # Implementation
 
@@ -92,11 +93,11 @@ struct SymbolicPullback{NNLT, FT} <: AbstractPullback{NNLT}
     fun::FT
 end
 
-function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss; cse::Bool = true)
+function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss; cse::Bool = true, inplace::Bool = true)
     @variables soutput[1:output_dimension(nn.model)]
     symbolic_loss = loss(nn.model, params(nn), nn.input, soutput)
     symbolic_pullbacks = symbolic_pullback(symbolic_loss, nn)
-    pbs_executable = build_nn_function(symbolic_pullbacks, params(nn), nn.input, soutput; reduce = +, cse = cse)
+    pbs_executable = build_nn_function(symbolic_pullbacks, params(nn), nn.input, soutput; reduce = +, cse = cse, inplace = inplace)
     function pbs(input, output, params)
         pullback(::Union{Real, AbstractArray{<:Real}}) = _get_contents(_get_params(pbs_executable(input, output, params)))
         pullback
@@ -104,7 +105,7 @@ function SymbolicPullback(nn::SymbolicNeuralNetwork, loss::NetworkLoss; cse::Boo
     SymbolicPullback(loss, pbs)
 end
 
-SymbolicPullback(nn::SymbolicNeuralNetwork; cse::Bool = true) = SymbolicPullback(nn, AbstractNeuralNetworks.FeedForwardLoss(); cse = cse)
+SymbolicPullback(nn::SymbolicNeuralNetwork; cse::Bool = true, inplace::Bool = true) = SymbolicPullback(nn, AbstractNeuralNetworks.FeedForwardLoss(); cse = cse, inplace = inplace)
 
 """
     _get_params(ps::NeuralNetworkParameters)

--- a/test/build_function/codegen_drift.jl
+++ b/test/build_function/codegen_drift.jl
@@ -9,15 +9,22 @@
 #   * the `SymbolicUtils.Code.create_array` constructor -> `fix_create_array`
 #   * the `(sinput, …)` / `(sinput, soutput, …)` signature -> `modify_input_arguments[2]`
 #   * the `getindex(sinput, i)` / `getindex(soutput, i)` accessors -> `make_kernel[2]`
+#   * the `(ˍ₋out, sinput, …)` signature                -> `modify_input_arguments_iip[2]`
+#   * the *linearly indexed* `ˍ₋out[i] = …` writes      -> `make_kernel_iip[2]`
 #
 # If an upstream release changes how code is generated (renamed arguments, a different
-# array constructor, CSE `let`-blocks, …), these regexes silently stop matching and the
-# generated functions become wrong or fail to compile. This test asserts the tokens are
-# still present at the pipeline stage each rewrite consumes them, so such drift fails here
-# with a clear message instead of surfacing as a confusing downstream error.
+# array constructor, …), these regexes silently stop matching and the generated functions
+# become wrong or fail to compile. This test asserts the tokens are still present at the
+# pipeline stage each rewrite consumes them, so such drift fails here with a clear message
+# instead of surfacing as a confusing downstream error.
+#
+# Both code-generation modes are checked. With `cse = true` (the default, see
+# `_build_nn_function`) the body becomes a `let` block of `var"##cse#N"` bindings; the
+# rewrites must survive that too. In particular Symbolics declines to hoist `getindex` of
+# `@variables`-created arrays into CSE bindings, which is what keeps `make_kernel` working.
 
 using SymbolicNeuralNetworks
-using SymbolicNeuralNetworks: _reduce
+using SymbolicNeuralNetworks: _reduce, _reduce_iip
 using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params
 using Symbolics
 using Symbolics: @variables
@@ -26,39 +33,78 @@ import Random
 
 Random.seed!(123)
 
-c = Chain(Dense(2, 3, tanh))
+# Two layers: a single `Dense` has no repeated subexpressions, so CSE would not kick in and
+# the `##cse#` assertion below would be vacuous.
+c = Chain(Dense(2, 3, tanh), Dense(3, 2, tanh))
 snn = SymbolicNeuralNetwork(c)
 nn = NeuralNetwork(c)
 
 # `fix_create_array` / `rewrite_arguments` / `modify_input_arguments` consume the *raw*
 # `build_function` output; `make_kernel` consumes it after a `Meta.parse` round-trip
 # (which normalises `(getindex)(x, i)` to `getindex(x, i)`), so we assert on both forms.
-@testset "single-input codegen tokens" begin
+@testset "single-input codegen tokens (cse = $cse)" for cse in (false, true)
     eq = Symbolics.scalarize(c(snn.input, params(snn)))
-    raw = string(_reduce(build_function(eq, snn.input, values(params(snn))...; expression = Val{true})))
+    raw = string(_reduce(build_function(eq, snn.input, values(params(snn))...; expression = Val{true}, cse = cse)))
     @test occursin("ˍ₋arg", raw)                            # rewrite_arguments
     @test occursin("SymbolicUtils.Code.create_array", raw)  # fix_create_array
     @test occursin("(sinput, ", raw)                        # modify_input_arguments assertion
     @test occursin(r"getindex\(sinput, [0-9]+\)", string(Meta.parse(raw)))  # make_kernel
+    # CSE must actually have happened, otherwise the assertions above are just a re-run of
+    # the `cse = false` case and no longer guard the `let`-block form.
+    @test occursin("##cse#", raw) == cse
 end
 
-@testset "double-input codegen tokens" begin
-    @variables soutput[1:3]
+@testset "double-input codegen tokens (cse = $cse)" for cse in (false, true)
+    @variables soutput[1:2]
     eq = Symbolics.scalarize((c(snn.input, params(snn)) - soutput) .^ 2)
-    raw = string(_reduce(build_function(eq, snn.input, soutput, values(params(snn))...; expression = Val{true})))
+    raw = string(_reduce(build_function(eq, snn.input, soutput, values(params(snn))...; expression = Val{true}, cse = cse)))
     @test occursin("ˍ₋arg", raw)                            # rewrite_arguments2
     @test occursin("SymbolicUtils.Code.create_array", raw)  # fix_create_array
     @test occursin("(sinput, soutput, ", raw)               # modify_input_arguments2 assertion
     normalised = string(Meta.parse(raw))
     @test occursin(r"getindex\(sinput, [0-9]+\)", normalised)   # make_kernel2
     @test occursin(r"getindex\(soutput, [0-9]+\)", normalised)  # make_kernel2
+    @test occursin("##cse#", raw) == cse
+end
+
+# The in-place half of `build_function`'s output is what `build_nn_function` actually runs.
+# Two properties of it are load-bearing and neither is documented upstream:
+#   * `ˍ₋out` is *not* counted in the `ˍ₋argN` numbering, so `rewrite_arguments` is reused as-is;
+#   * the output is addressed with a single *linear* index whatever the shape of the equation,
+#     which is what lets `make_kernel_iip` offset the writes by the batch index instead of
+#     handing the kernel a view.
+@testset "in-place codegen tokens (cse = $cse)" for cse in (false, true)
+    vector_valued = Symbolics.scalarize(c(snn.input, params(snn)))
+    matrix_valued = Symbolics.scalarize(SymbolicNeuralNetworks.derivative(SymbolicNeuralNetworks.Jacobian(snn)))
+    @test ndims(matrix_valued) == 2  # otherwise the linear-indexing check below is vacuous
+
+    for eq in (vector_valued, matrix_valued)
+        raw = string(_reduce_iip(build_function(eq, snn.input, values(params(snn))...; expression = Val{true}, cse = cse)))
+        @test occursin("(ˍ₋out, sinput, ", raw)                 # modify_input_arguments_iip assertion
+        @test occursin("ˍ₋arg2", raw)                           # rewrite_arguments: numbering starts at 2, not 3
+        @test occursin(r"getindex\(sinput, [0-9]+\)", string(Meta.parse(raw)))  # make_kernel_iip
+        @test occursin(r"ˍ₋out\[[0-9]+\] = ", string(Meta.parse(raw)))          # redirect_output_writes
+        @test !occursin(r"ˍ₋out\[[0-9]+, [0-9]+\] = ", string(Meta.parse(raw))) # ... linear, never cartesian
+    end
+end
+
+@testset "in-place double-input codegen tokens (cse = $cse)" for cse in (false, true)
+    @variables soutput[1:2]
+    eq = Symbolics.scalarize((c(snn.input, params(snn)) - soutput) .^ 2)
+    raw = string(_reduce_iip(build_function(eq, snn.input, soutput, values(params(snn))...; expression = Val{true}, cse = cse)))
+    @test occursin("(ˍ₋out, sinput, soutput, ", raw)        # modify_input_arguments_iip2 assertion
+    @test occursin("ˍ₋arg3", raw)                           # rewrite_arguments2: numbering starts at 3, not 4
+    normalised = string(Meta.parse(raw))
+    @test occursin(r"getindex\(sinput, [0-9]+\)", normalised)   # make_kernel_iip2
+    @test occursin(r"getindex\(soutput, [0-9]+\)", normalised)  # make_kernel_iip2
+    @test occursin(r"ˍ₋out\[[0-9]+\] = ", normalised)           # redirect_output_writes
 end
 
 # End-to-end guard: even if the token checks above are satisfied, the assembled function
 # must still evaluate correctly over a batch (this exercises the `k`-indexing that
 # `make_kernel` injects).
-@testset "assembled function is correct over a batch" begin
-    f = build_nn_function(c(snn.input, params(snn)), params(snn), snn.input)
+@testset "assembled function is correct over a batch (cse = $cse)" for cse in (false, true)
+    f = build_nn_function(c(snn.input, params(snn)), params(snn), snn.input; cse = cse)
     x = rand(2, 5)
     @test f(x, params(nn)) ≈ reduce(hcat, [c(x[:, k], params(nn)) for k in axes(x, 2)])
 end

--- a/test/build_function/cse_equivalence.jl
+++ b/test/build_function/cse_equivalence.jl
@@ -1,0 +1,59 @@
+# `cse = true` is the default for all code generation (see `_build_nn_function`). It changes
+# *how* the expression is printed — a `let` block of shared bindings instead of a fully
+# inlined tree — but must never change *what* is computed. These tests pin that down for
+# every expression shape the package generates code for: plain forward passes, derivatives
+# with respect to the input (`Jacobian`), derivatives with respect to the parameters
+# (`Gradient`), the `NamedTuple`-valued builders, and the full `SymbolicPullback`.
+
+using SymbolicNeuralNetworks
+using SymbolicNeuralNetworks: Jacobian, Gradient, derivative
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params, FeedForwardLoss
+using Test
+import Random
+
+Random.seed!(123)
+
+# deep enough that CSE actually has something to share
+c = Chain(Dense(3, 4, tanh), Dense(4, 2, tanh))
+snn = SymbolicNeuralNetwork(c)
+nn = NeuralNetwork(c)
+ps = params(nn)
+
+input = rand(3, 5)
+output = rand(2, 5)
+
+@testset "forward pass" begin
+    eq = c(snn.input, params(snn))
+    @test build_nn_function(eq, snn)(input, ps) ≈
+          build_nn_function(eq, snn; cse = false)(input, ps)
+end
+
+@testset "Jacobian (derivative w.r.t. the input)" begin
+    eq = derivative(Jacobian(snn))
+    @test build_nn_function(eq, snn)(input, ps) ≈
+          build_nn_function(eq, snn; cse = false)(input, ps)
+end
+
+@testset "Gradient (derivative w.r.t. the parameters)" begin
+    eq = derivative(Gradient(snn))[1].L1.W
+    @test build_nn_function(eq, snn)(input, ps) ≈
+          build_nn_function(eq, snn; cse = false)(input, ps)
+end
+
+@testset "NamedTuple-valued equations" begin
+    eqs = (a = c(snn.input, params(snn)), b = c(snn.input, params(snn)) .^ 2)
+    with_cse = build_nn_function(eqs, params(snn), snn.input)(input, ps)
+    without_cse = build_nn_function(eqs, params(snn), snn.input; cse = false)(input, ps)
+    @test with_cse.a ≈ without_cse.a
+    @test with_cse.b ≈ without_cse.b
+end
+
+@testset "SymbolicPullback" begin
+    loss = FeedForwardLoss()
+    with_cse = SymbolicPullback(snn, loss)(ps, c, (input, output))[2](1.0)
+    without_cse = SymbolicPullback(snn, loss; cse = false)(ps, c, (input, output))[2](1.0)
+    for layer in keys(with_cse)
+        @test with_cse[layer].W ≈ without_cse[layer].W
+        @test with_cse[layer].b ≈ without_cse[layer].b
+    end
+end

--- a/test/build_function/cse_equivalence.jl
+++ b/test/build_function/cse_equivalence.jl
@@ -22,38 +22,48 @@ ps = params(nn)
 input = rand(3, 5)
 output = rand(2, 5)
 
+"Values, shape and concrete type must all be unaffected by how the code was printed."
+function compare(with_cse, without_cse)
+    @test with_cse ≈ without_cse
+    @test size(with_cse) == size(without_cse)
+    @test typeof(with_cse) == typeof(without_cse)
+end
+
 @testset "forward pass" begin
     eq = c(snn.input, params(snn))
-    @test build_nn_function(eq, snn)(input, ps) ≈
-          build_nn_function(eq, snn; cse = false)(input, ps)
+    compare(build_nn_function(eq, snn)(input, ps),
+            build_nn_function(eq, snn; cse = false)(input, ps))
 end
 
 @testset "Jacobian (derivative w.r.t. the input)" begin
     eq = derivative(Jacobian(snn))
-    @test build_nn_function(eq, snn)(input, ps) ≈
-          build_nn_function(eq, snn; cse = false)(input, ps)
+    compare(build_nn_function(eq, snn)(input, ps),
+            build_nn_function(eq, snn; cse = false)(input, ps))
 end
 
 @testset "Gradient (derivative w.r.t. the parameters)" begin
     eq = derivative(Gradient(snn))[1].L1.W
-    @test build_nn_function(eq, snn)(input, ps) ≈
-          build_nn_function(eq, snn; cse = false)(input, ps)
+    compare(build_nn_function(eq, snn)(input, ps),
+            build_nn_function(eq, snn; cse = false)(input, ps))
 end
 
 @testset "NamedTuple-valued equations" begin
     eqs = (a = c(snn.input, params(snn)), b = c(snn.input, params(snn)) .^ 2)
     with_cse = build_nn_function(eqs, params(snn), snn.input)(input, ps)
     without_cse = build_nn_function(eqs, params(snn), snn.input; cse = false)(input, ps)
-    @test with_cse.a ≈ without_cse.a
-    @test with_cse.b ≈ without_cse.b
+    @test keys(with_cse) == keys(without_cse)
+    for key in keys(with_cse)
+        compare(with_cse[key], without_cse[key])
+    end
 end
 
 @testset "SymbolicPullback" begin
     loss = FeedForwardLoss()
     with_cse = SymbolicPullback(snn, loss)(ps, c, (input, output))[2](1.0)
     without_cse = SymbolicPullback(snn, loss; cse = false)(ps, c, (input, output))[2](1.0)
+    @test keys(with_cse) == keys(without_cse)
     for layer in keys(with_cse)
-        @test with_cse[layer].W ≈ without_cse[layer].W
-        @test with_cse[layer].b ≈ without_cse[layer].b
+        compare(with_cse[layer].W, without_cse[layer].W)
+        compare(with_cse[layer].b, without_cse[layer].b)
     end
 end

--- a/test/build_function/inplace_equivalence.jl
+++ b/test/build_function/inplace_equivalence.jl
@@ -10,11 +10,14 @@
 # Some combinations are not supported by either path (a 3-D input is reshaped assuming a
 # vector-valued equation); those are expected to fail the same way, which is what
 # `compare_or_both_fail` checks.
+#
+# The out-of-place path is still reachable through `inplace = false`, which is what these tests use
+# as the reference — it is also the escape hatch for reverse-mode AD, see
+# `test/build_function/zygote_differentiability.jl`.
 
 using SymbolicNeuralNetworks
-using SymbolicNeuralNetworks: Jacobian, Gradient, derivative, _build_nn_function,
-                              _oop_batch_wrapper, _oop_batch_wrapper2
-using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params
+using SymbolicNeuralNetworks: Jacobian, Gradient, derivative
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params, NeuralNetworkParameters
 using Symbolics
 using Symbolics: @variables
 using Test
@@ -51,7 +54,7 @@ end
         reduce in (hcat, +)
 
     f_iip = build_nn_function(eq, params(snn), snn.input; reduce = reduce)
-    f_oop = _oop_batch_wrapper(_build_nn_function(eq, params(snn), snn.input), reduce)
+    f_oop = build_nn_function(eq, params(snn), snn.input; reduce = reduce, inplace = false)
 
     compare_or_both_fail(f_iip, f_oop, rand(3, 6), ps)       # batch
     compare_or_both_fail(f_iip, f_oop, rand(3, 1), ps)       # batch of one
@@ -67,7 +70,7 @@ end
         reduce in (hcat, +)
 
     f_iip = build_nn_function(eq, params(snn), snn.input, soutput; reduce = reduce)
-    f_oop = _oop_batch_wrapper2(_build_nn_function(eq, params(snn), snn.input, soutput), reduce)
+    f_oop = build_nn_function(eq, params(snn), snn.input, soutput; reduce = reduce, inplace = false)
 
     compare_or_both_fail(f_iip, f_oop, rand(3, 6), rand(2, 6), ps)
     compare_or_both_fail(f_iip, f_oop, rand(3, 1), rand(2, 1), ps)
@@ -85,4 +88,18 @@ end
     @test eltype(f(rand(3, 4), ps)) == Float64
     # mixed inputs promote
     @test eltype(f(rand(Float32, 3, 4), ps)) == Float64
+end
+
+# An equation over integer inputs does not evaluate to an integer, so the promoted type has to be
+# widened before the kernel writes into the array — otherwise this is an `InexactError`.
+@testset "integer inputs are widened, reduce = $reduce" for reduce in (hcat, +)
+    f_iip = build_nn_function(c(snn.input, params(snn)), params(snn), snn.input; reduce = reduce)
+    f_oop = build_nn_function(c(snn.input, params(snn)), params(snn), snn.input; reduce = reduce, inplace = false)
+    int_ps = NeuralNetworkParameters((L1 = (W = ones(Int, 4, 3), b = zeros(Int, 4)),
+                                      L2 = (W = ones(Int, 2, 4), b = zeros(Int, 2))))
+    int_input = [1 2; 3 4; 5 6]
+    @test f_iip(int_input, int_ps) ≈ f_oop(int_input, int_ps)
+    @test eltype(f_iip(int_input, int_ps)) == Float64
+    # a float input against integer parameters must not be widened past Float64 either
+    @test eltype(f_iip(rand(3, 2), int_ps)) == Float64
 end

--- a/test/build_function/inplace_equivalence.jl
+++ b/test/build_function/inplace_equivalence.jl
@@ -1,0 +1,88 @@
+# `build_nn_function` evaluates a batch with an *in-place* kernel that writes every column
+# into one preallocated array (see `_build_nn_function_iip`). It used to call an out-of-place
+# kernel once per column and combine the results with `Base.reduce(reduce, …)`.
+#
+# The in-place kernel addresses its output linearly and offsets the writes by the batch index,
+# so the layout of the result is reproduced by arithmetic rather than by `hcat`/`+`. These
+# tests pin that layout down against the out-of-place path it replaced — same values *and* same
+# shape — for every combination of equation shape, input shape and `reduce` mode.
+#
+# Some combinations are not supported by either path (a 3-D input is reshaped assuming a
+# vector-valued equation); those are expected to fail the same way, which is what
+# `compare_or_both_fail` checks.
+
+using SymbolicNeuralNetworks
+using SymbolicNeuralNetworks: Jacobian, Gradient, derivative, _build_nn_function,
+                              _oop_batch_wrapper, _oop_batch_wrapper2
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params
+using Symbolics
+using Symbolics: @variables
+using Test
+import Random
+
+Random.seed!(123)
+
+c = Chain(Dense(3, 4, tanh), Dense(4, 2, tanh))
+snn = SymbolicNeuralNetwork(c)
+nn = NeuralNetwork(c)
+ps = params(nn)
+
+"""
+Compare the in-place and out-of-place results, requiring both value *and* shape to agree.
+If the out-of-place path does not support the combination either, require that the in-place
+path fails too rather than silently returning something different.
+"""
+function compare_or_both_fail(f_iip, f_oop, args...)
+    oop_result = try
+        f_oop(args...)
+    catch
+        @test_throws Exception f_iip(args...)
+        return
+    end
+    iip_result = f_iip(args...)
+    @test iip_result ≈ oop_result
+    @test size(iip_result) == size(oop_result)
+end
+
+@testset "single input, $name, reduce = $reduce" for
+        (name, eq) in ("vector-valued" => c(snn.input, params(snn)),
+                       "matrix-valued (Jacobian)" => derivative(Jacobian(snn)),
+                       "matrix-valued (Gradient)" => derivative(Gradient(snn))[1].L1.W),
+        reduce in (hcat, +)
+
+    f_iip = build_nn_function(eq, params(snn), snn.input; reduce = reduce)
+    f_oop = _oop_batch_wrapper(_build_nn_function(eq, params(snn), snn.input), reduce)
+
+    compare_or_both_fail(f_iip, f_oop, rand(3, 6), ps)       # batch
+    compare_or_both_fail(f_iip, f_oop, rand(3, 1), ps)       # batch of one
+    compare_or_both_fail(f_iip, f_oop, rand(3), ps)          # single vector
+    compare_or_both_fail(f_iip, f_oop, rand(3, 2, 3), ps)    # 3-D input
+end
+
+@variables soutput[1:2]
+
+@testset "two inputs, $name, reduce = $reduce" for
+        (name, eq) in ("vector-valued" => (c(snn.input, params(snn)) - soutput) .^ 2,
+                       "matrix-valued" => derivative(Gradient((c(snn.input, params(snn)) - soutput) .^ 2, snn))[1].L1.W),
+        reduce in (hcat, +)
+
+    f_iip = build_nn_function(eq, params(snn), snn.input, soutput; reduce = reduce)
+    f_oop = _oop_batch_wrapper2(_build_nn_function(eq, params(snn), snn.input, soutput), reduce)
+
+    compare_or_both_fail(f_iip, f_oop, rand(3, 6), rand(2, 6), ps)
+    compare_or_both_fail(f_iip, f_oop, rand(3, 1), rand(2, 1), ps)
+    compare_or_both_fail(f_iip, f_oop, rand(3), rand(2), ps)
+    compare_or_both_fail(f_iip, f_oop, rand(3, 2, 3), rand(2, 2, 3), ps)
+end
+
+# The output array is allocated before the kernel runs, so its element type comes from
+# `promoted_eltype` rather than from the result. `Float32` parameters must not be silently
+# widened to `Float64` (nor the other way round).
+@testset "element type follows the inputs" begin
+    f = build_nn_function(c(snn.input, params(snn)), params(snn), snn.input)
+    nn32 = NeuralNetwork(c, Float32)
+    @test eltype(f(rand(Float32, 3, 4), params(nn32))) == Float32
+    @test eltype(f(rand(3, 4), ps)) == Float64
+    # mixed inputs promote
+    @test eltype(f(rand(Float32, 3, 4), ps)) == Float64
+end

--- a/test/build_function/joint_codegen.jl
+++ b/test/build_function/joint_codegen.jl
@@ -1,0 +1,105 @@
+# `build_nn_function` generates all entries of a `NamedTuple`- or
+# `NeuralNetworkParameters`-valued equation set as ONE function and splits the flat result
+# afterwards (`flatten_eqs` / `unflatten`), instead of one function per entry.
+#
+# The split has to reproduce, entry by entry, exactly what the per-entry path produced —
+# values, shapes and concrete types — for both `reduce` modes and for batched as well as
+# single-vector inputs. `_build_nn_function_per_leaf` is still around as the fallback for
+# scalar-valued entries, which makes it the reference to compare against.
+
+using SymbolicNeuralNetworks
+using SymbolicNeuralNetworks: _build_nn_function_per_leaf, flatten_eqs, unflatten, FlatSlice
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params, NeuralNetworkParameters
+using Symbolics
+using Symbolics: @variables
+using Test
+import Random
+
+Random.seed!(123)
+
+c = Chain(Dense(3, 4, tanh), Dense(4, 2, tanh))
+snn = SymbolicNeuralNetwork(c)
+nn = NeuralNetwork(c)
+ps = params(nn)
+
+function compare_entries(joint, per_leaf)
+    @test keys(joint) == keys(per_leaf)
+    for key in keys(joint)
+        if joint[key] isa Union{NamedTuple, NeuralNetworkParameters}
+            compare_entries(joint[key], per_leaf[key])
+        else
+            @test joint[key] ≈ per_leaf[key]
+            @test size(joint[key]) == size(per_leaf[key])
+            @test typeof(joint[key]) == typeof(per_leaf[key])
+        end
+    end
+end
+
+@testset "flatten_eqs / unflatten round-trip" begin
+    eqs = (a = c(snn.input, params(snn)), b = c(snn.input, params(snn)) .^ 2)
+    flat, template = flatten_eqs(eqs)
+    @test length(flat) == 4          # two entries of length 2
+    @test template.a isa FlatSlice
+    @test template.a.range == 1:2
+    @test template.b.range == 3:4
+    # the ranges must tile the flat vector exactly, without gaps or overlap
+    @test vcat(collect(template.a.range), collect(template.b.range)) == 1:length(flat)
+
+    # scalar entries have no in-place kernel, so the set must be rejected
+    @variables scalar_eq
+    @test isnothing(flatten_eqs((a = c(snn.input, params(snn)), b = scalar_eq)))
+end
+
+@testset "NamedTuple-valued equations agree with per-entry codegen, reduce = $reduce" for reduce in (hcat, +)
+    eqs = (a = c(snn.input, params(snn)), b = c(snn.input, params(snn)) .^ 2)
+    joint = build_nn_function(eqs, params(snn), snn.input; reduce = reduce)
+    per_leaf = _build_nn_function_per_leaf(eqs, params(snn), snn.input; reduce = reduce)
+
+    for input in (rand(3, 6), rand(3, 1), rand(3))
+        compare_entries(joint(input, ps), per_leaf(input, ps))
+    end
+end
+
+@variables soutput[1:2]
+
+@testset "two-input equations agree with per-entry codegen, reduce = $reduce" for reduce in (hcat, +)
+    eqs = (a = (c(snn.input, params(snn)) - soutput) .^ 2, b = c(snn.input, params(snn)))
+    joint = build_nn_function(eqs, params(snn), snn.input, soutput; reduce = reduce)
+    per_leaf = _build_nn_function_per_leaf(eqs, params(snn), snn.input, soutput; reduce = reduce)
+
+    for (input, output) in ((rand(3, 6), rand(2, 6)), (rand(3, 1), rand(2, 1)), (rand(3), rand(2)))
+        compare_entries(joint(input, output, ps), per_leaf(input, output, ps))
+    end
+end
+
+@testset "nested NeuralNetworkParameters (the shape a pullback has), reduce = $reduce" for reduce in (hcat, +)
+    eqs = SymbolicNeuralNetworks.symbolic_pullback(c(snn.input, params(snn)), snn)[1]
+    @test eqs isa NeuralNetworkParameters       # two levels of nesting: layer, then W/b
+    joint = build_nn_function(eqs, params(snn), snn.input; reduce = reduce)
+    per_leaf = _build_nn_function_per_leaf(eqs, params(snn), snn.input; reduce = reduce)
+
+    input = rand(3, 6)
+    compare_entries(joint(input, ps), per_leaf(input, ps))
+end
+
+@testset "entries do not alias one another" begin
+    eqs = (a = c(snn.input, params(snn)), b = c(snn.input, params(snn)))
+    result = build_nn_function(eqs, params(snn), snn.input)(rand(3, 4), ps)
+    before = copy(result.b)
+    result.a .= 0
+    @test result.b == before
+end
+
+@testset "equation sets containing a scalar fall back to per-entry codegen" begin
+    # `collect` before reducing: reductions over an un-scalarized `Symbolics.Arr` produce an
+    # `arrayop`, whose generated code refers to variables that nothing binds (independent of
+    # `cse`) — see `build_function_generated`.
+    scalar_eq = sum(collect(c(snn.input, params(snn))))
+    eqs = (a = c(snn.input, params(snn)), b = scalar_eq)
+    @test isnothing(flatten_eqs(eqs))    # the joint path must decline this set
+
+    f = build_nn_function(eqs, params(snn), snn.input)
+    input = rand(3, 4)
+    @test f(input, ps).a ≈ reduce(hcat, [c(input[:, k], ps) for k in axes(input, 2)])
+    @test vec(f(input, ps).b) ≈ [sum(c(input[:, k], ps)) for k in axes(input, 2)]
+end

--- a/test/build_function/zygote_differentiability.jl
+++ b/test/build_function/zygote_differentiability.jl
@@ -1,0 +1,71 @@
+# `build_nn_function` evaluates a batch with an *in-place* kernel by default: it allocates the
+# result and lets the generated code mutate it (see `_build_nn_function_iip`). `Zygote` does not
+# support mutation, so the default result cannot be differentiated in reverse mode — which matters,
+# because generated functions are used *inside* losses downstream (`GeometricMachineLearning`'s
+# `HNNLoss` calls `build_nn_function(hvf, …)` and differentiates the loss with `Zygote`).
+#
+# `inplace = false` keeps the out-of-place path, which is differentiable at the cost of one array
+# per batch column. These tests pin both halves of that contract down: that the opt-out works and
+# gives the right derivative, and that the default is the mutating one (so the day someone makes it
+# differentiable, this test tells them the keyword has become redundant).
+#
+# Forward-mode AD is unaffected: the preallocated array takes its element type from the inputs
+# (`promoted_eltype`), so `ForwardDiff.Dual` numbers flow through the in-place path too.
+
+using SymbolicNeuralNetworks
+using AbstractNeuralNetworks: Chain, Dense, NeuralNetwork, params, NeuralNetworkParameters,
+                              FeedForwardLoss
+using Test
+import ForwardDiff
+import Random
+import Zygote
+
+Random.seed!(123)
+
+c = Chain(Dense(3, 4, tanh), Dense(4, 2, tanh))
+snn = SymbolicNeuralNetwork(c)
+nn = NeuralNetwork(c)
+ps = params(nn)
+eq = c(snn.input, params(snn))
+input = rand(3, 5)
+
+@testset "the out-of-place path is Zygote-differentiable, reduce = $reduce" for reduce in (hcat, +)
+    f = build_nn_function(eq, params(snn), snn.input; reduce = reduce, inplace = false)
+    grad = Zygote.gradient(p -> sum(f(input, p)), ps)[1]
+    @test grad isa Union{NamedTuple, NeuralNetworkParameters}
+
+    # the same derivative through the chain itself, which needs no code generation at all
+    reference = Zygote.gradient(p -> sum(Base.reduce(reduce, [c(input[:, k], p) for k in axes(input, 2)])), ps)[1]
+    for layer in keys(ps), array in keys(ps[layer])
+        @test grad[layer][array] ≈ reference[layer][array]
+    end
+end
+
+@testset "the two-input out-of-place path is Zygote-differentiable" begin
+    output = rand(2, 5)
+    pb = SymbolicPullback(snn, FeedForwardLoss(); inplace = false)
+    # differentiating the *loss* still works; what is exercised here is that the pullback itself
+    # can be built and evaluated in out-of-place mode
+    @test pb(ps, c, (input, output))[2](1.0) isa NamedTuple
+end
+
+# Pin the current limitation. If this starts failing the in-place path became differentiable and
+# the `inplace` keyword is no longer needed for `Zygote`.
+@testset "the default (in-place) path is not Zygote-differentiable" begin
+    f = build_nn_function(eq, params(snn), snn.input)
+    @test_throws Exception Zygote.gradient(p -> sum(f(input, p)), ps)
+end
+
+# Forward-mode AD does not care about mutation, so it must work on *both* paths: the array the
+# in-place kernel writes into is allocated with the promoted element type, which is the `Dual`.
+@testset "ForwardDiff works either way" begin
+    W = ps.L1.W
+    rewrap(w) = NeuralNetworkParameters((L1 = (W = reshape(w, size(W)...), b = ps.L1.b), L2 = ps.L2))
+    grads = map((true, false)) do inplace
+        f = build_nn_function(eq, params(snn), snn.input; inplace = inplace)
+        ForwardDiff.gradient(w -> sum(f(input, rewrap(w))), vec(W))
+    end
+    reference = ForwardDiff.gradient(w -> sum(c(input, rewrap(w))), vec(W))
+    @test grads[1] ≈ reference
+    @test grads[2] ≈ reference
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ end
 @safetestset "Joint codegen agrees with per-entry codegen                                             " begin
     include("build_function/joint_codegen.jl")
 end
+@safetestset "Generated functions are differentiable                                                  " begin
+    include("build_function/zygote_differentiability.jl")
+end
 @safetestset "Compare Zygote Pullback with Symbolic Pullback                                         " begin
     include("derivatives/pullback.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,15 @@ end
 @safetestset "Codegen-drift guard for the Symbolics string pipeline                                  " begin
     include("build_function/codegen_drift.jl")
 end
+@safetestset "CSE does not change the computed values                                                 " begin
+    include("build_function/cse_equivalence.jl")
+end
+@safetestset "In-place kernels agree with the out-of-place ones                                       " begin
+    include("build_function/inplace_equivalence.jl")
+end
+@safetestset "Joint codegen agrees with per-entry codegen                                             " begin
+    include("build_function/joint_codegen.jl")
+end
 @safetestset "Compare Zygote Pullback with Symbolic Pullback                                         " begin
     include("derivatives/pullback.jl")
 end


### PR DESCRIPTION
## Context

Code generation, not symbolic differentiation, is the bottleneck in this package — `expand_derivatives` takes 0.3 s even for the deepest network measured here, while `Symbolics.build_function` took a minute. Three things compounded:

1. **Symbolics stores an expression as a hash-consed DAG but `build_function` prints it as a tree.** Every reuse of a subexpression — layer *n*'s output feeding each neuron of layer *n+1*, or the forward pass shared by every block of a symbolic pullback — was emitted again, so code size grew exponentially with depth. `build_function` has a `cse` keyword that emits a `let` block of shared bindings instead; the package never set it.
2. **`function_valued_parameters` built one `RuntimeGeneratedFunction` per parameter array**, each re-deriving the whole forward pass, each compiled separately.
3. **Only the out-of-place half of `build_function`'s output was kept**, and it was called once per batch column — one array allocated per column, then combined with `Base.reduce`.

## Results

Generated pullback code for a 5-10-10-10-1 network shrinks from **437 MB to 1.8 MB (247×)**. Measured against `main`; gradient values identical to 16 digits in every case:

| network | `main` (batch 100) | this PR |
|---|---|---|
| 5-10-1 | 2.907 ms, 622 KiB | **0.026 ms, 20.8 KiB** |
| 5-10-10-1 | killed after 5 min (1.8 B allocations) | **0.062 ms**, builds in 9 s |
| 5-10-10-10-1 | infeasible | **0.255 ms**, builds in 1.4 s |

Networks with more than one hidden layer were effectively unusable before.

`scripts/codegen_comparison.jl` reproduces these numbers.

## What's in it

**CSE, on by default.** `cse::Bool = true` threaded through every builder and `SymbolicPullback`, with `cse = false` to opt out — a single-`Dense` network gets marginally *larger* code under CSE, and an escape hatch is useful if the upstream CSE pass regresses.

**In-place batched kernels.** `_build_nn_function_iip` keeps the in-place half of `build_function`'s output. That code addresses its result *linearly* whatever the shape of the equation, which is what lets `make_kernel_iip` turn the batch index into an offset (`reduce = hcat`) or an accumulation (`reduce = +`) rather than handing the kernel a view. `ˍ₋out` is also not counted in the `ˍ₋argN` numbering, so `rewrite_arguments` is reused unchanged. Both properties are undocumented upstream and now have assertions in the codegen-drift guard.

**Joint codegen.** `flatten_eqs` / `unflatten` generate a `NamedTuple`- or `NeuralNetworkParameters`-valued equation set as one function and split the flat result afterwards. Entries are copied out rather than viewed, so they stay ordinary `Array`s and cannot alias. Sets containing a scalar entry keep the per-entry path (`_build_nn_function_per_leaf`), since `build_function` emits no in-place form for scalars.

## ⚠️ Breaking: the default result is no longer `Zygote`-differentiable

The in-place kernels mutate a preallocated array, which `Zygote` does not support. This matters because generated functions are used *inside* losses downstream: `GeometricMachineLearning`'s `HNNLoss` builds its Hamiltonian vector field with `build_nn_function` and differentiates the loss with `Zygote`, so `Zygote.gradient(ps -> loss(ps, input, output), nn.params)` now throws `Mutating arrays is not supported`.

`inplace::Bool = true` is therefore threaded exactly as `cse` is, keeping the out-of-place path reachable:

```julia
f = build_nn_function(eq, params(snn), snn.input; inplace = false)   # differentiable
```

The default keeps the speedup; `inplace = false` costs an array per batch column. Joint code generation is independent of the keyword — the whole equation set is still generated as one function either way. Forward-mode AD was never affected, since the preallocated array takes its element type from the inputs.

**`GeometricMachineLearning` needs a one-word change**: `hamiltonian_vector_field` (`src/architectures/hamiltonian_neural_network.jl`) should pass `inplace = false`. Verified that this restores `test_hnn_loss_derivative` with the loss value unchanged.

## Notes

- **`redirect_output_writes` could not fail.** A `replace` that matches nothing returns the string unchanged and the kernel still compiles — it just writes every batch column into the same place (`reduce = hcat`) or overwrites instead of accumulating (`reduce = +`), i.e. silently returns wrong numbers. It now asserts that the generated code assigns each entry of the equation exactly once, which holds for every equation shape and both `cse` modes. Every other rewrite in the pipeline either asserts already or fails loudly downstream.
- **`promoted_eltype` derives the element type from the inputs, not the expression**, because the array has to exist before the kernel runs. An equation over integer inputs *and* integer parameters does not evaluate to an integer, so that combination threw an `InexactError` where the out-of-place path returned a `Float64` array; the allocators now widen integer types with `float`.
- **A scalar equation generated its code twice.** `_build_nn_function_iip` ran `build_function` in full before `_reduce_iip` discarded the result, and `_build_nn_function` then repeated it. Skipping the in-place attempt for scalars takes a 5-10-10-10-1 network from 1.136 s to 0.619 s.
- **Documents an unrelated pre-existing limitation found along the way:** reductions over un-scalarized symbolic arrays (`sum(c(input, ps))`) generate code referring to variables nothing binds, and fail with an `UndefVarError` — with *or* without CSE. Reducing over `collect(c(input, ps))` works. Noted on `build_function_generated`.
- The in-place change on its own is worth ~1.0–1.6× in time and 3–10× in allocations once CSE is in place; the headline speedup above comes from CSE plus joint codegen.

## Verification

- Full suite + doctests pass (434 tests), including the existing Zygote-vs-symbolic pullback comparison. Documentation builds with all cross-references resolved.
- New tests assert CSE, the in-place kernels and the joint codegen each reproduce the previous results — values, shapes *and* concrete types — across equation shapes, input shapes and both `reduce` modes: `test/build_function/{cse_equivalence,inplace_equivalence,joint_codegen}.jl`.
- `test/build_function/zygote_differentiability.jl` pins both halves of the AD contract: `inplace = false` differentiates and matches a reference gradient, the default throws, and `ForwardDiff` works either way.
- `test/build_function/codegen_drift.jl` extended to cover CSE and in-place codegen tokens in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
