### PR TITLE
Drop the GeometricMachineLearning test dependency and set version to 0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 AbstractNeuralNetworks = "0.3, 0.4, 0.5, 0.6"
 Documenter = "1.8.0"
 ForwardDiff = "1"
-GeometricMachineLearning = "0.4.7"
 Latexify = "0.16"
 RuntimeGeneratedFunctions = "0.5"
 SymbolicUtils = "4"
@@ -32,7 +31,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-GeometricMachineLearning = "194d25b2-d3f5-49f0-af24-c124f4aa80cc"
 
 [targets]
-test = ["Test", "ForwardDiff", "Random", "Documenter", "Latexify", "SafeTestsets", "Zygote", "GeometricMachineLearning"]
+test = ["Test", "ForwardDiff", "Random", "Documenter", "Latexify", "SafeTestsets", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicNeuralNetworks"
 uuid = "aed23131-dcd0-47ca-8090-d21e605652e3"
-version = "0.3.7"
+version = "0.4.0"
 authors = ["Michael Kraus"]
 
 [deps]

--- a/test/derivatives/pullback.jl
+++ b/test/derivatives/pullback.jl
@@ -3,11 +3,16 @@ using SymbolicNeuralNetworks: _get_params, _get_contents
 using AbstractNeuralNetworks
 using AbstractNeuralNetworks: params
 using Symbolics
-using GeometricMachineLearning: ZygotePullback
 import Zygote
 using Test
 import Random
 Random.seed!(123)
+
+# This used to be `GeometricMachineLearning.ZygotePullback`, which is the one line below. It is
+# inlined here so that the test suite does not depend on `GeometricMachineLearning`: that package
+# has a compat bound on `SymbolicNeuralNetworks`, so depending on it in the other direction means
+# neither can be released without the other having been released first.
+zygote_pullback(loss, ps, model, input_output::Tuple) = Zygote.pullback(p -> loss(model, p, input_output...), ps)
 
 compare_values(arr1::Array, arr2::Array) = @test arr1 ≈ arr2
 function compare_values(nt1::NamedTuple, nt2::NamedTuple)
@@ -26,8 +31,7 @@ function compare_symbolic_pullback_to_zygote_pullback(input_dim::Integer, output
     # note that we apply the second argument to another input `1`
     pb_values = loss_and_pullback[2](1)
 
-    zpb = ZygotePullback(loss)
-    loss_and_pullback_zygote = zpb(params(nn), nn.model, input_output)
+    loss_and_pullback_zygote = zygote_pullback(loss, params(nn), nn.model, input_output)
     pb_values_zygote = loss_and_pullback_zygote[2](1) |> _get_contents |> _get_params
 
     compare_values(pb_values, pb_values_zygote)

--- a/test/derivatives/symbolic_gradient.jl
+++ b/test/derivatives/symbolic_gradient.jl
@@ -3,7 +3,6 @@ using SymbolicNeuralNetworks: symbolic_differentials, symbolic_derivative, _buil
 using LinearAlgebra: norm
 using Symbolics, AbstractNeuralNetworks
 using AbstractNeuralNetworks: NeuralNetworkParameters, params
-using GeometricMachineLearning
 
 import Zygote
 import Random


### PR DESCRIPTION
Prepares the 0.4.0 release of #46.

## Why 0.4.0

#46 is breaking: the function returned by `build_nn_function` now evaluates a batch with an in-place kernel and can no longer be differentiated with `Zygote`. `inplace = false` gives the previous, differentiable behaviour back. For a `0.x` package that is a minor bump.

## Why the `GeometricMachineLearning` test dependency has to go first

`GeometricMachineLearning` declares `SymbolicNeuralNetworks = "0.3"` from 0.4.2 onwards. Depending on it from the test target therefore means neither package can have a breaking release without the other having been released first — setting the version to 0.4.0 makes this package's own test environment unsatisfiable:

```
GeometricMachineLearning [194d25b2]:
 ├─restricted to versions 0.4.7 - 0.4 by project
 └─restricted by compatibility requirements with SymbolicNeuralNetworks
   to versions: 0.1.0 - 0.4.1 — no versions left
```

Exactly one test used it, for `ZygotePullback`, which is a single call to `Zygote.pullback`:

```julia
zygote_pullback(loss, ps, model, input_output::Tuple) = Zygote.pullback(p -> loss(model, p, input_output...), ps)
```

That is inlined in `test/derivatives/pullback.jl`; the comparison it makes — symbolic pullback against Zygote's — is unchanged and still passes. `test/derivatives/symbolic_gradient.jl` imported the package without using anything from it (`Chain`, `Dense` and `NeuralNetwork` all come from `AbstractNeuralNetworks`).

## Documentation

The docs still use `GeometricMachineLearning` and keep doing so. `docs/Project.toml` carries no compat bound, so the docs environment resolves it to whatever version allows the current `SymbolicNeuralNetworks` — 0.4.1 for the moment, rather than 0.4.8. Verified that a from-scratch resolve plus a full `docs/make.jl` build succeeds with all cross-references resolved. It will pick the current release again once `GeometricMachineLearning` relaxes its bound.

## Follow-up in another repo

`GeometricMachineLearning` needs two changes once 0.4.0 is registered:

1. `SymbolicNeuralNetworks = "0.3, 0.4"` in `[compat]`.
2. `hamiltonian_vector_field` (`src/architectures/hamiltonian_neural_network.jl`) must pass `inplace = false`, otherwise `HNNLoss` can no longer be differentiated with `Zygote`. Verified that this restores `test_hnn_loss_derivative` with the loss value unchanged.

## Verification

Full suite + doctests pass (434 tests) at version 0.4.0 with `GeometricMachineLearning` removed, and `docs/make.jl` builds cleanly against a freshly resolved docs environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
